### PR TITLE
add french translation

### DIFF
--- a/TomeAndBlood/TomeAndBlood.tp2
+++ b/TomeAndBlood/TomeAndBlood.tp2
@@ -31,6 +31,12 @@ END
 /* Language Settings */
 AUTO_TRA ~TomeAndBlood/lang/%s~
 LANGUAGE ~English~ ~english~ ~TomeAndBlood/lang/english/setup.tra~ 
+LANGUAGE ~French~ ~french~
+		~TomeAndBlood/lang/french/setup.tra~
+		~TomeAndBlood/lang/french/cantrips.tra~
+		~TomeAndBlood/lang/french/crafting.tra~
+		~TomeAndBlood/lang/french/familiars.tra~
+		~TomeAndBlood/lang/french/spells.tra~
 
 
 // -----------------------------

--- a/TomeAndBlood/comp/setup_cantrips.tpa
+++ b/TomeAndBlood/comp/setup_cantrips.tpa
@@ -653,7 +653,9 @@ ACTION_IF !(FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN
 	PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 		READ_STRREF 0x50 "desc"
 		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-			REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+			SPRINT lv1 @150000
+			SPRINT lv2 @150001
+			REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 		END
 		SAY_EVALUATED 0x50 ~%new_desc%~
 	END
@@ -671,7 +673,9 @@ ACTION_IF !(FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN
 		PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 			READ_STRREF 0x54 "desc"
 			INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-				REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+				SPRINT lv1 @150000
+				SPRINT lv2 @150001
+				REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 			END
 			SAY_EVALUATED 0x54 ~%new_desc%~
 		END
@@ -711,7 +715,9 @@ ADD_SPELL ~override/spwi108.spl~ 2 2 WIZARD_PROTECTION_FROM_PETRIFICATION
 	PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 		READ_STRREF 0x50 "desc"
 		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-			REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+			SPRINT lv1 @150000
+			SPRINT lv2 @150001
+			REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 		END
 		SAY_EVALUATED 0x50 ~%new_desc%~
 	END
@@ -729,7 +735,9 @@ ACTION_IF (FILE_EXISTS_IN_GAME ~scrl73.itm~) BEGIN
 		PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 			READ_STRREF 0x54 "desc"
 			INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-				REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+				SPRINT lv1 @150000
+				SPRINT lv2 @150001
+				REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 			END
 			SAY_EVALUATED 0x54 ~%new_desc%~
 		END
@@ -976,7 +984,9 @@ ACTION_IF !(FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN
 	PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 		READ_STRREF 0x50 "desc"
 		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-			REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+			SPRINT lv1 @150000
+			SPRINT lv2 @150001
+			REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 		END
 		SAY_EVALUATED 0x50 ~%new_desc%~
 	END
@@ -994,7 +1004,9 @@ ACTION_IF !(FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN
 		PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 			READ_STRREF 0x54 "desc"
 			INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-				REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+				SPRINT lv1 @150000
+				SPRINT lv2 @150001
+				REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 			END
 			SAY_EVALUATED 0x54 ~%new_desc%~
 		END
@@ -1053,7 +1065,9 @@ ACTION_IF (FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN
 	PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 		READ_STRREF 0x50 "desc"
 		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-			REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+			SPRINT lv1 @150000
+			SPRINT lv2 @150001
+			REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 		END
 		SAY_EVALUATED 0x50 ~%new_desc%~
 	END
@@ -1185,7 +1199,9 @@ ACTION_IF (FILE_EXISTS_IN_GAME ~spwi124.spl~) BEGIN
 	PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
 		READ_STRREF 0x50 "desc"
 		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-			REPLACE_TEXTUALLY ~Level: 1~ ~Level: 2~
+			SPRINT lv1 @150000
+			SPRINT lv2 @150001
+			REPLACE_TEXTUALLY ~%lv1%~ ~%lv2%~
 		END
 		SAY_EVALUATED 0x50 ~%new_desc%~
 	END

--- a/TomeAndBlood/comp/setup_spell_schools.tpa
+++ b/TomeAndBlood/comp/setup_spell_schools.tpa
@@ -106,39 +106,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~ ~
-							REPLACE_TEXTUALLY ~(Divination)~ ~ ~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~ ~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~ ~
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~ ~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~ ~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~ ~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~ ~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~ ~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Universal~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Universal ~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT universal_sr @160110
+					SPRINT universal_no_sr @160150
+					LPF update_school STR_VAR school_no_sr = universal_no_sr school_sr = universal_sr END
 				END
 			BUT_ONLY
 		END
@@ -154,39 +124,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~ ~
-							REPLACE_TEXTUALLY ~(Divination)~ ~ ~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~ ~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~ ~
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~ ~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~ ~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~ ~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~ ~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~ ~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~ ~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Universal ~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Universal ~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT universal_sr @160110
+					SPRINT universal_no_sr @160150
+					LPF update_school STR_VAR school_no_sr = universal_no_sr school_sr = universal_sr END
 				END
 			BUT_ONLY
 		END
@@ -208,37 +148,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Abjuration)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Abjuration~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT abjuration_sr @160100
+					SPRINT abjuration_no_sr @160140
+					LPF update_school STR_VAR school_no_sr = abjuration_no_sr school_sr = abjuration_sr END
 				END
 			BUT_ONLY
 		END
@@ -254,37 +166,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Abjuration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Abjuration)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Abjuration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Abjuration~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT abjuration_sr @160100
+					SPRINT abjuration_no_sr @160140
+					LPF update_school STR_VAR school_no_sr = abjuration_no_sr school_sr = abjuration_sr END
 				END
 			BUT_ONLY
 		END
@@ -306,37 +190,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Alteration)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Alteration~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT alteration_sr @160101
+					SPRINT alteration_no_sr @160141
+					LPF update_school STR_VAR school_no_sr = alteration_no_sr school_sr = alteration_sr END
 				END
 			BUT_ONLY
 		END
@@ -352,37 +208,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Alteration)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Alteration)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Alteration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Alteration~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT alteration_sr @160101
+					SPRINT alteration_no_sr @160141
+					LPF update_school STR_VAR school_no_sr = alteration_no_sr school_sr = alteration_sr END
 				END
 			BUT_ONLY
 		END
@@ -404,36 +232,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Conjuration/Summoning)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Conjuration~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT conjuration_sr @160102
+					SPRINT conjuration_no_sr @160142
+					LPF update_school STR_VAR school_no_sr = conjuration_no_sr school_sr = conjuration_sr END
 				END
 			BUT_ONLY
 		END
@@ -449,37 +250,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Conjuration/Summoning)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Conjuration/Summoning)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Conjuration~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Conjuration~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT conjuration_sr @160102
+					SPRINT conjuration_no_sr @160142
+					LPF update_school STR_VAR school_no_sr = conjuration_no_sr school_sr = conjuration_sr END
 				END
 			BUT_ONLY
 		END
@@ -501,37 +274,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Divination)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Divination~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT divination_sr @160103
+					SPRINT divination_no_sr @160143
+					LPF update_school STR_VAR school_no_sr = divination_no_sr school_sr = divination_sr END
 				END
 			BUT_ONLY
 		END
@@ -547,37 +292,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Divination)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Divination)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Divination~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Divination~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT divination_sr @160103
+					SPRINT divination_no_sr @160143
+					LPF update_school STR_VAR school_no_sr = divination_no_sr school_sr = divination_sr END
 				END
 			BUT_ONLY
 		END
@@ -599,37 +316,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Enchantment/Charm)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Enchantment~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT enchantment_sr @160104
+					SPRINT enchantment_no_sr @160144
+					LPF update_school STR_VAR school_no_sr = enchantment_no_sr school_sr = enchantment_sr END
 				END
 			BUT_ONLY
 		END
@@ -645,37 +334,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Enchantment/Charm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Enchantment/Charm)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Enchantment~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Enchantment~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT enchantment_sr @160104
+					SPRINT enchantment_no_sr @160144
+					LPF update_school STR_VAR school_no_sr = enchantment_no_sr school_sr = enchantment_sr END
 				END
 			BUT_ONLY
 		END
@@ -697,37 +358,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Evocation)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Evocation~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT evocation_sr @160105
+					SPRINT evocation_no_sr @160145
+					LPF update_school STR_VAR school_no_sr = evocation_no_sr school_sr = evocation_sr END
 				END
 			BUT_ONLY
 		END
@@ -743,37 +376,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Evocation)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Evocation)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Evocation~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Evocation~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT evocation_sr @160105
+					SPRINT evocation_no_sr @160145
+					LPF update_school STR_VAR school_no_sr = evocation_no_sr school_sr = evocation_sr END
 				END
 			BUT_ONLY
 		END
@@ -795,37 +400,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Illusion/Phantasm)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Illusion~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT illusion_sr @160106
+					SPRINT illusion_no_sr @160146
+					LPF update_school STR_VAR school_no_sr = illusion_no_sr school_sr = illusion_sr END
 				END
 			BUT_ONLY
 		END
@@ -841,37 +418,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Necromancy)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Illusion/Phantasm)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Illusion/Phantasm)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Illusion~
-							REPLACE_TEXTUALLY ~: Necromancy~ ~: Illusion~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT illusion_sr @160106
+					SPRINT illusion_no_sr @160146
+					LPF update_school STR_VAR school_no_sr = illusion_no_sr school_sr = illusion_sr END
 				END
 			BUT_ONLY
 		END
@@ -893,37 +442,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x50 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x50 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Necromancy)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Necromancy~
-						END
-					END
-					SAY_EVALUATED 0x50 ~%new_desc%~
+					SPRINT necromancy_sr @160107
+					SPRINT necromancy_no_sr @160147
+					LPF update_school STR_VAR school_no_sr = necromancy_no_sr school_sr = necromancy_sr END
 				END
 			BUT_ONLY
 		END
@@ -939,37 +460,9 @@ ACTION_PHP_EACH d5_scroll_spell_school AS scroll => school BEGIN
 				END
 				READ_LONG 0x54 "valid"
 				PATCH_IF (%valid% >= 0) BEGIN // verify name is valid
-					READ_STRREF 0x54 "desc"
-					PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~(Illusion/Phantasm)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Divination)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Enchantment/Charm)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Evocation)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Abjuration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Invocation/Evocation)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Alteration, Illusion)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Evocation, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Divination, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Abjuration, Alteration)~ ~(Necromancy)~
-							REPLACE_TEXTUALLY ~(Conjuration/Summoning, Invocation/Evocation)~ ~(Necromancy)~
-						END
-					END
-					PATCH_IF FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // SR
-						INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
-							REPLACE_TEXTUALLY ~: Illusion~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Alteration~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Conjuration~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Divination~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Enchantment~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Evocation~ ~: Necromancy~
-							REPLACE_TEXTUALLY ~: Abjuration~ ~: Necromancy~
-						END
-					END
-					SAY_EVALUATED 0x54 ~%new_desc%~
+					SPRINT necromancy_sr @160107
+					SPRINT necromancy_no_sr @160147
+					LPF update_school STR_VAR school_no_sr = necromancy_no_sr school_sr = necromancy_sr END
 				END
 			BUT_ONLY
 		END
@@ -1474,3 +967,107 @@ END
 
 
 END 	//	end define function
+
+DEFINE_PATCH_FUNCTION update_school STR_VAR school_no_sr = ~~ school_sr = ~~ BEGIN
+	SPRINT school_desc_1 @160000
+	SPRINT school_desc_2 @160001
+	SPRINT school_desc_3 @160002
+	SPRINT school_desc_4 @160003
+	SPRINT school_desc_5 @160004
+	SPRINT school_desc_6 @160005
+	SPRINT school_desc_7 @160006
+	SPRINT school_desc_8 @160007
+	SPRINT school_desc_9 @160008
+	SPRINT school_desc_10 @160009
+	SPRINT school_desc_11 @160010
+	SPRINT school_desc_12 @160011
+	SPRINT school_desc_13 @160012
+	SPRINT school_desc_14 @160013
+	SPRINT school_desc_15 @160014
+	SPRINT school_desc_16 @160015
+	SPRINT school_desc_17 @160016
+	SPRINT school_desc_18 @160017
+	SPRINT school_desc_19 @160018
+	SPRINT school_desc_20 @160019
+	SPRINT school_desc_21 @160020
+	SPRINT school_desc_22 @160021
+	SPRINT school_desc_23 @160022
+	SPRINT school_desc_24 @160023
+	SPRINT school_desc_25 @160024
+	SPRINT school_desc_26 @160025
+	SPRINT school_desc_27 @160026
+	SPRINT school_desc_28 @160027
+	SPRINT school_desc_29 @160028
+	SPRINT school_desc_30 @160029
+	SPRINT school_desc_31 @160030
+	SPRINT school_desc_32 @160031
+	SPRINT school_desc_33 @160032
+	SPRINT school_desc_34 @160033
+	SPRINT school_desc_35 @160034
+	SPRINT school_desc_36 @160035
+
+	SPRINT abjuration @160100
+	SPRINT alteration @160101
+	SPRINT conjuration @160102
+	SPRINT divination @160103
+	SPRINT enchantment @160104
+	SPRINT evocation @160105
+	SPRINT illusion @160106
+	SPRINT necromancy @160107
+	SPRINT universal @160110
+
+	READ_STRREF 0x54 "desc"
+
+	PATCH_IF NOT FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~ BEGIN // no SR
+		INNER_PATCH_SAVE new_desc ~%desc%~ BEGIN
+			REPLACE_TEXTUALLY ~%school_desc_1%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_2%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_3%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_4%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_5%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_6%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_7%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_8%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_9%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_10%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_11%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_12%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_13%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_14%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_15%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_16%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_17%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_18%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_19%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_20%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_21%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_22%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_23%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_24%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_25%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_26%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_27%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_28%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_29%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_30%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_31%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_32%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_33%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_34%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_35%~ ~%school_no_sr%~
+			REPLACE_TEXTUALLY ~%school_desc_36%~ ~%school_no_sr%~
+		END
+	END
+	ELSE BEGIN
+		REPLACE_TEXTUALLY ~%abjuration%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%alteration%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%conjuration%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%divination%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%enchantment%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%evocation%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%illusion%~ ~%school_sr%~
+		REPLACE_TEXTUALLY ~%necromancy%~ ~%school_sr%~
+	END
+
+	SAY_EVALUATED 0x50 ~%new_desc%~
+END

--- a/TomeAndBlood/comp/setup_spell_tweaks.tpa
+++ b/TomeAndBlood/comp/setup_spell_tweaks.tpa
@@ -353,7 +353,9 @@ ACTION_IF (FILE_EXISTS_IN_GAME ~dvsrv4here.mrk~) BEGIN 	// no need to patch 203 
 	READ_STRREF 0x54 ~description~
 	PATCH_IF (~%description%~ STRING_CONTAINS_REGEXP ~5 rounds~) = 0 BEGIN
 	  INNER_PATCH_SAVE new_desc ~%description%~ BEGIN
-		REPLACE_TEXTUALLY ~5 rounds~ ~10 rounds~
+		  SPRINT old_duration @150003
+		  SPRINT new_duration @150004
+		REPLACE_TEXTUALLY ~%old_duration%~ ~%new_duration%~
 	  END
 	  SAY_EVALUATED 0x54 ~%new_desc%~
 	END
@@ -761,8 +763,10 @@ ACTION_IF FILE_CONTAINS_EVALUATED (~SPELL.IDS~ ~WIZARD_IDENTIFY~)	BEGIN
 
  ACTION_IF (identify_level > 1) BEGIN
   OUTER_SPRINT identify_desc @7104
+  OUTER_SPRINT level1_regex @150000
+  OUTER_SPRINT new_level @150002
   OUTER_INNER_PATCH_SAVE new_identify_desc ~%identify_desc%~ BEGIN
-    REPLACE_TEXTUALLY ~Level: 1~ ~Level: %identify_level%~
+    REPLACE_TEXTUALLY ~%level1_regex%~ ~%new_level%%identify_level%~
   END
  END
 

--- a/TomeAndBlood/lang/english/setup.tra
+++ b/TomeAndBlood/lang/english/setup.tra
@@ -2656,3 +2656,69 @@ You can brew potions if you have the right spell and enough gold.~
 @115256 = ~Craft Item
 You can craft and recharge items, if you have the right spell and enough gold.~
 
+// used to replace Level:1 with Level: 2 in spell descriptions and for identify spell tweak
+@150000 = ~Level: 1~
+@150001 = ~Level: 2~
+@150002 = ~Level: ~
+// invisibility tweak
+@150003 = ~5 rounds~ //original
+@150004 = ~10 rounds~ //replacement
+
+// used to remove school from a scroll description
+// no SR
+@160000 = ~(Abjuration)~
+@160001 = ~(Alteration)~
+@160002 = ~(Conjuration)~
+@160003 = ~(Conjuration/Summoning)~
+@160004 = ~(Divination)~
+@160005 = ~(Enchantment/Charm)~
+@160006 = ~(Evocation)~
+@160007 = ~(Illusion/Phantasm)~
+@160008 = ~(Necromancy)~
+@160009 = ~(Invocation/Evocation)~
+@160010 = ~(Alteration, Illusion)~
+@160011 = ~(Evocation, Alteration)~
+@160012 = ~(Divination, Alteration)~
+@160013 = ~(Abjuration, Alteration)~
+@160014 = ~(Conjuration/Summoning, Invocation/Evocation)~
+@160015 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160016 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160017 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160018 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160019 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160020 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160021 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160023 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160024 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160025 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160026 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160027 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160028 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160029 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160030 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160031 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160032 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160033 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160034 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160035 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+//SR replacement
+@160100 = ~: Abjuration~
+@160101 = ~: Alteration~
+@160102 = ~: Conjuration~
+@160103 = ~: Divination~
+@160104 = ~: Enchantment~
+@160105 = ~: Evocation~
+@160106 = ~: Illusion~
+@160107 = ~: Necromancy~
+@160110 = ~: Universal~
+//non-SR replacement
+@160140 = ~(Abjuration)~
+@160141 = ~(Alteration)~
+@160142 = ~(Conjuration/Summoning)~
+@160143 = ~(Divination)~
+@160144 = ~(Enchantment/Charm)~
+@160145 = ~(Evocation)~
+@160146 = ~(Illusion/Phantasm)~
+@160147 = ~(Necromancy)~
+@160150 = ~ ~ //universal
+

--- a/TomeAndBlood/lang/french/cantrips.tra
+++ b/TomeAndBlood/lang/french/cantrips.tra
@@ -1,0 +1,407 @@
+
+
+@6010   = ~Baguette de tours de magie~
+@6011   = ~Au tout début de leur apprentissage de la magie, avant de décider de se spécialiser ou non, les mages apprennent les effets les plus simples et anodins de chaque école de magie. Encore incapable de lancer réellement des sorts, ils exécutent ces tours de magie à l'aide d'une baguette. Ce n'est ni plus ni moins qu'une béquille, mais au moins, cela évite d'avoir à mémoriser les sorts et la baguette ne risque pas de tomber à court de charge.
+
+Le mage peut utiliser la baguette de tours de magie comme arme à distance, en lançant un sort de Carreau magique sur un ennemi une fois par round. Le carreau inflige 1d4+1 points de dégâts magiques (Le mage est alors en situation désavantageuse vis-à-vis des ennemis au corps à corps avec lui). Il a aussi la possibilité d'utiliser la baguette pour lancer l'un des tours de magie suivants :
+- Coquille protectrice : bloque un coup physique porté sur le magicien. La coquille dure 3 tours.
+- Convocation de lapin : convoque un petit rongeur à côté du magicien pendant 3 rounds.
+- Anticipation : donne au lanceur un aperçu du futur immédiat, ce qui lui donne un bonus de 3 points à la CA.
+- Somnolence : la cible s'endort pour 1 round sur un échec au jet de sauvegarde contre les sorts.
+- Égarement : la cible subit une pénalité de 1 point au TAC0 et à la CA pour 1 round. Sur un échec au jet de sauvegarde contre les souffles, les pénalités sont doublées et durent 2 rounds et la cible est aveuglée le premier round.
+- Raidissement des os : la cible souffre d'une raideur douloureuse, avec une pénalité de 1 point au TAC0 et aux dégâts pendant 1 round. Sur un échec au jet de sauvegarde contre la mort, les pénalités sont doublées, durent 2 rounds et la cible est ralentie pendant le premier round.
+- Poigne terreuse : la cible est enchevêtrée pendant 2 rounds, incapable de se déplacer, sur un échec au jet de sauvegarde contre la pétrification.~
+@6012   = ~Choisir un tour de magie~
+@6013   = ~Ce pouvoir représente la faculté magique la plus élémentaire du magicien. Il permet au mage de choisir un des tours de magie suivants :
+- Coquille protectrice
+- Convocation de lapin
+- Anticipation
+- Somnolence
+- Égarement
+- Raidissement des os
+- Poigne terreuse
+- Carreau magique
+~
+@6014   = ~Coquille protectrice~
+@6015   = ~Coquille protectrice
+
+Niveau : 0
+Portée : 0
+Durée : 3 tours
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée une fine coquille magique qui absorbe sans dégât le premier coup physique qui frappe le lanceur.~
+@6016   = ~Convocation de lapin~
+@6017   = ~Convocation de lapin
+
+Niveau : 0
+Portée : 0
+Durée : 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie convoque un rongeur de taille moyenne à l'endroit indiqué par le lanceur.~
+@6018   = ~Lapin~
+@6019   = ~Anticipation~
+@6020   = ~Anticipation
+
+Niveau : 0
+Portée : 0
+Durée : 3 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie accorde au lanceur une faculté de prémonition temporaire qui couvre le futur immédiat, ce qui se traduit par un bonus de 3 points à la CA à cause du temps de réaction amélioré.~
+@6021   = ~Somnolence~
+@6022   = ~Somnolence
+
+Niveau : 0
+Portée : 6 m
+Durée : 1 round
+Zone d'effet : 1 cible
+Jet de sauvegarde : sorts annule
+
+Ce tour de magie amène la cible à s'assoupir brièvement et à s'affaler au sol pendant 6 secondes avant de se réveiller complètement.~
+@6023   = ~Égarement~
+@6024   = ~Égarement
+
+Niveau : 0
+Portée : 6 m
+Durée : 2 rounds
+Zone d'effet : 1 cible
+Jet de sauvegarde : sorts annule
+
+Ce tour de magique crée une lumière intense et scintillante devant les yeux de la cible. Il subit une pénalité de 1 point au TAC0, aux jets de dégâts et à la CA pendant 12 secondes (s'il échoue au jet de sauvegarde contre les sorts, les pénalités passent à 3 points et la victime est aveuglée pendant 6 secondes).~
+@6025   = ~Carreau magique~
+@6026   = ~Carreau magique
+
+Niveau : 0
+Portée : 6 m
+Durée : instantanée
+Zone d'effet : 1 cible
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit carreau d'énergie magique qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+@6027   = ~Raidissement des os~
+@6028   = ~Raidissement des os
+
+Niveau : 0
+Portée : 6 m
+Durée : 2 rounds
+Zone d'effet : 1 cible
+Jet de sauvegarde : mort, annule
+La cible de ce tour de magie souffre d'une raideur douloureuse, avec une pénalité de 1 point au TAC0 et aux dégâts pendant 12 secondes. Sur un échec au jet de sauvegarde contre la mort, les pénalités sont doublées et la cible est ralentie.~
+@6029   = ~Poigne terreuse~
+@6030   = ~Poigne terreuse : la cible est enchevêtrée pendant 2 rounds, incapable de se déplacer, sur un échec au jet de sauvegarde contre la pétrification.
+
+Niveau : 0
+Portée : 6 m
+Durée : 2 rounds
+Zone d'effet : 1 cible
+Jet de sauvegarde : souffles, annule
+
+Ce tour de magie fait apparaître des vrilles du sol qui s'accrochent aux jambes de la cible et l'empêchent de se déplacer quelques secondes. Su un échec au jet de sauvegarde contre les souffles, la cible est immobilisée pour quelques secondes et incapable de se déplacer pour le round qui suit.~
+@6031   = ~Carreau de feu~
+@6032   = ~Carreau de feu
+
+Niveau : 0
+Portée : 0
+Durée: 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit carreau de feu magique qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+@6033   = ~Carreau glacé~
+@6034   = ~Carreau glacé
+
+Niveau : 0
+Portée : 0
+Durée: 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit carreau de froid magique qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+@6035   = ~Carreau acide~
+@6036   = ~Carreau acide
+
+Niveau : 0
+Portée : 0
+Durée: 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit carreau d'acide qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+@6037   = ~Carreau électrique~
+@6038   = ~Carreau électrique
+
+Niveau : 0
+Portée : 0
+Durée: 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit éclair électrique qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+@6039   = ~Carreau de terre~
+@6040   = ~Carreau de terre
+
+Niveau : 0
+Portée : 0
+Durée: 5 rounds
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce tour de magie crée un petit bloc de pierre qui s'échappe des mains du lanceur et inflige 1d5 points de dégâts à la cible.~
+
+/////////////////////////
+// level one cantrips
+/////////////////////////
+
+//Grease: no stacking with itself
+@7011  = ~Glisse~
+@7012  = ~Glisse
+(Transmutation)
+
+Niveau : 1
+Portée : 9 mètres
+Durée : 4 rounds
+Temps d'incantation : 1
+Zone d'effet : rayon de 9 mètres
+Jet de sauvegarde : spécial
+
+Le sort de glisse permet de recouvrir une surface matérielle d'une substance huileuse et glissante. Toute créature s'aventurant ou prise au piège dans la zone d'effet au moment où le sort est lancé doit réussir un jet de sauvegarde contre les sorts, sans quoi elle glisse et dérape, étant incapable de bouger. Toute créature réussissant un jet de sauvegarde peut se déplacer, mais lentement, pour le reste du round (mais devra à nouveau faire un jet de sauvegarde contre les souffles au round). Celles qui restent dans la zone d'effet ont droit à un jet de sauvegarde à chaque round jusqu'à ce qu'elles réussissent à quitter la zone.
+~
+
+//Burning Hands: reduced damage
+@7031  = ~Mains ardentes~
+@7032  = ~Mains ardentes
+(Transmutation)
+
+Niveau : 1
+Portée : 1,5 m
+Durée : Instantanée
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : 1/2
+
+Lorsque le magicien lance ce sort, un jet de flammes brûlantes jaillit du bout de ses doigts. Il doit joindre ses deux pouces et placer ses autres doigts en éventail pour que les flammes puissent jaillir vers l'avant. Ces flammes font 1,5 m de long, sur un arc horizontal d'environ 120 degrés devant le magicien. La cible subit 1d4 points de dégâts, +1 point tous les 3 niveaux du lanceur, jusqu'à un maximum de 1d4+6 points de dégâts de feu. Une créature réussissant un jet de sauvegarde contre les sorts ne subit que la moitié des dégâts.
+~
+//Charm Person: one try only, victim cannot attack
+@7041  = ~Charme-personne~
+@7042  = ~Charme-personne
+(Enchantement/Charme)
+
+Niveau : 1
+Portée : Champ visuel du lanceur
+Durée : 5 rounds
+Temps d'incantation : 1
+Zone d'effet : 1 personne
+Jet de sauvegarde : annule
+
+Ce sort affecte tout individu auquel il est jeté. Il peut s'agir de tout humain, demi-homme ou humanoïde bipède de taille inférieure ou égale à celle d'un homme (lutin, dryade, nain, elfe, gnoll, gnome, gobelin, demi-elfe, petite-personne, demi-orque, hobgobelin, humain, kobold, homme-lézard, nixe, orque, pixie, esprit-follet, troglodyte, etc.). Ainsi, un guerrier du 10ème niveau pourra être charmé, mais pas un ogre. La personne peut faire un jet de sauvegarde contre les sorts pour éviter son effet.
+
+Si la cible de l'enchantement rate son jet de sauvegarde contre les sorts (avec un modificateur de +3), il considère le lanceur comme un véritable ami et allié méritant son attention et sa protection. Ce dernier peut donner des ordres au bénéficiaire qui les exécute le plus vite possible, mis à part que la personne charmée ne peut se voir contrainte à la violence.
+
+Si la personne charmée est blessée ou si un sort de dissipation de la magie est lancé sur la personne charmée, le charme est rompu. Si deux sorts de charme ou plus affectent une créature, le sort le plus récent est appliqué. Si plusieurs effets de charmes affectent simultanément une créature, le charme le plus récent prend le dessus. Notez que le sujet se souvient parfaitement des événements qui ont eu lieu lorsqu'il était sous le charme. Notez aussi que vous ne pouvez faire quitter à la créature la zone dans laquelle elle a été charmée.
+
+Toute personne qui a été la cible de ce sort, qu'elle ait réussi son jet de sauvegarde ou non, sera méfiante pendant un certain temps et ne pourra être affectée par le sort pendant 8 heures.
+~
+//Color Spray: replace Sleep w/ Slow (no SR)
+@7052  = ~Vapeur colorée
+(Transmutation)
+
+Niveau : 1
+Portée : 15 mètres
+Durée : Instantanée
+Temps d'incantation : 1
+Zone d'effet : arc de 90 degrés
+Jet de sauvegarde : spécial
+
+Grâce à ce sort, un éventail de couleurs vives jaillit de la main du magicien. Entre une et six créatures (1d6) situées dans la zone sont affectées dans l'ordre croissant de leur proximité au magicien. Toute créature dans la zone d'effet doit réussir un jet de sauvegarde, sous peine d'être ralentie pour 2 rounds.
+~
+//Blindness: change to Dazzle (very short duration)
+@7061  = ~Cécité~
+@7062  = ~Cécité
+(Illusion/Fantasme)
+
+Niveau : 1
+Portée : 12 mètres
+Durée : 2 rounds
+Temps d'incantation : 2
+Zone d'effet : 1 créature
+Jet de sauvegarde : annule
+
+Ce sort de premier niveau aveugle temporairement la cible. Un jet de sauvegarde est permis. S'il réussit, la cible ne subit qu'une pénalité d'un point aux jets d'attaque, de dégâts et à la CA pendant 2 rounds. Si le jet échoue, la victime, aveuglée, a un champ de vision réduit et reçoit un malus de 4 points à ses jets d'attaque et à sa classe d'armure. Cette cécité disparaît après 2 rounds.
+~
+// conjure rabbit as lv1
+@7073  = ~Convocation de lapin~
+@7074  = ~Convocation de lapin
+
+Niveau : 1
+École : Conjuration
+Portée : le lanceur
+Durée : 5 rounds
+Temps d'incantation : 5
+Zone d'effet : spéciale
+Jet de sauvegarde : Aucun
+
+Le lanceur convoque un lapin de taille moyenne à l'endroit, qui apparaît de nulle part. Le lapin est obéissant et suivra les instructions mentales du lanceur, allant jusqu'à mordre les ennemis. Un lapin ainsi convoqué ne restera que 5 rounds.
+~
+@7075   = ~Lapin~
+// Magic Missile - less missiles
+@7121  = ~Projectile magique~
+@7122  = ~Projectile magique
+(Évocation)
+
+Niveau : 1
+Portée : Champ visuel du lanceur
+Durée : Instantanée
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : aucun
+
+Ce sort permet de créer jusqu'à trois projectiles d'énergie magique qui fusent du bout des doigts du magicien et frappent à coup sûr leur cible, qui doit être une créature. Contre les créatures, chaque projectile inflige 1d4+1 points de dégâts. Le sort produit un projectile au niveau 1, deux projectiles au niveau 3 et trois projectiles au niveau 9.
+~
+
+//Wand of Magic Missiles: fire 2 missiles each charge
+@7125  = ~Baguette de projectiles magiques~
+@7126  = ~Une fois activée, la baguette crache deux projectiles d'énergie magique qui filent toucher automatiquement leur cible, y compris un ennemi engagé dans un combat au corps à corps. La créature doit être vue, ou au moins détectable, si bien qu'une couverture presque totale, telle celle qu'offre une archère, peut rendre le projectile inopérant. Ceux-ci infligent 1d4+1 points de dégâts à la créature qu'ils frappent.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- 2 projectiles magiques vont frapper la cible
+  Dégâts : 1d4+1
+  Portée : 30,5 m
+  Zone d'effet : 1 créature
+
+Nécessite :
+ 9 en Intelligence
+
+Poids : 1
+~
+// Shocking Grasp - no SR
+@7151  = ~Poigne électrique~
+@7152  = ~Poigne électrique
+(Transmutation)
+
+Niveau : 1
+Portée : contact
+Durée : spéciale
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : aucun
+
+Avec ce sort, un magicien inflige 1d8 points de dégâts de décharge électrique +1 par tranche de 2 niveaux du lanceur à une créature en la touchant (jusqu’à un maximum de 1d8+5 points de dégâts au niveau 10). En outre, le coup de poing en lui-même inflige 1d2 dégâts (le bonus de force aux dégâts s'applique). Le magicien ne dispose que d'une seule décharge : une fois l'adversaire touché, l'énergie du sort a été utilisée. Si le magicien le rate, le sort est gaspillé. Il dispose également d'un round par niveau pour toucher la créature ciblée avant que le sort ne se dissipe.
+~
+// Shocking Grasp - SR - damage 1d6xlevel/2 -> 2d4 + level/2
+@7154  = ~Poigne Électrique
+Niveau : 1
+École : Évocation
+Portée : jeteur du sort
+Durée : spéciale
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : spécial
+
+Quand le magicien touche une créature alors que ce sort est en action, une charge électrique lui infligera 2d4 points de dégâts et étourdira la cible pendant un round. Si la cible réussit son jet de sauvegarde contre les sorts, elle n'est pas étourdie. Pour chaque tranche de deux niveaux supplémentaires du lanceur du sort, la créature subit 1 point de dégâts supplémentaires et une pénalité de 1 point lors du jet de sauvegarde (jusqu'à un maximum de 2d4+4 points de dégâts et de 4 points de pénalité au jet de sauvegarde au niveau 9). Le sort expire lorsque le mage réussit une attaque au corps-à-corps ou après 1 tour. Le mage reçoit un bonus de 4 points pour toucher la cible.
+~
+//Sleep: add Drowse at 1st level, replace PW Sleep with Sleep at 2nd level
+@7161  = ~Somnolence~
+@7162  = ~Somnolence
+(Enchantement/Charme)
+
+Niveau : 1
+Portée 18 m
+Durée : 5 rounds
+Temps d'incantation : 1
+Zone d'effet : rayon de 9 m
+Jet de sauvegarde : annule
+
+Lorsque le magicien lance un sort de sommeil, il provoque un état comateux chez une créature (autres que les morts-vivants et certaines créatures à l'abri des effets de ce sort particulier). La créature doit réussir un jet de sauvegarde contre les sorts ou s'endormir. Les attaques contre les adversaires endormis n'échouent jamais.
+
+Si la créature endormie subit des dégâts, elle se réveille doucement sur une durée de 1 round. De plus, une fois qu'une créature a été endormie par ce sort, elle ne peut être affectée dans les 8 heures qui suivent.
+~
+@7163  = ~Sommeil~
+@7164  = ~Sommeil
+(Enchantement/Charme)
+
+Niveau : 1
+Portée 18 m
+Durée : 5 rounds
+Temps d'incantation : 1
+Zone d'effet : rayon de 9 m
+Jet de sauvegarde : annule
+
+Lorsque le magicien lance un sort de sommeil, il provoque un état comateux chez une ou plusieurs créatures (autres que les morts-vivants et certaines créatures à l'abri des effets de ce sort particulier). Toutes les créatures affectées doivent se trouver à 9 mètres de distance les unes des autres. Les créatures dans la zone d'effet doivent réussir un jet de sauvegarde avec un malus de 3 points ou s'endormir. Les monstres possédant 5 DV ou plus ne sont pas affectés. Les attaques contre les adversaires endormis n'échouent jamais.
+
+Si la créature endormie subit des dégâts, elle se réveille doucement sur une durée de 1 round. De plus, une fois qu'une créature a été endormie par ce sort, elle ne peut être affectée dans les 8 heures qui suivent.
+~
+
+//Chromatic Orb: reduce power, randomize effects
+@7181  = ~Orbe chromatique~
+@7182  = ~Orbe chromatique
+(Évocation)
+
+Niveau : 1
+Portée : 27 m
+Durée : Spéciale
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : spécial
+
+Ce sort crée une sphère de 60 centimètres de diamètre dans la main du jeteur de sorts. Une fois le sort lancé, la sphère se dirige vers sa cible, qu'elle atteint inévitablement. L'effet de l'orbe sur la cible varie. Chaque orbe inflige des dégâts et un autre effet (qui peut être annulé par un jet de sauvegarde contre les sorts à +2) :
+  20 % de chance : 1d4 points de dégâts et aveugle la cible pendant 1 round.
+  20 % de chance : 1d4 points de dégâts et inflige de la douleur (1 point de pénalité à la force, la dextérité, la CA et au TAC0) à la cible.
+  20 % de chance : 1d4 points de dégâts et étourdit la cible pour 1 round.
+  20 % de chance : 1d4 points de dégâts et inflige un affaiblissement (pénalité de 4 points au TAC0) à la cible pour 5 rounds.
+  20 % de chance : 1d4 points de dégâts et fait paniquer la cible pour 2 rounds.
+~
+//LMD: no spamming extra hp
+@7191  = ~Absorption mineure de Larloch~
+@7192  = ~Absorption mineure de Larloch
+(Nécromancie)
+
+Niveau : 1
+Portée : 9 mètres
+Durée : Spéciale
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : aucun
+
+Grâce à ce sort, le magicien absorbe la force vitale d'une cible pour l'ajouter à la sienne. La créature visée subit 2d3 points de dégâts, tandis que le mage gagne 4 points de vie. Si le mage dépasse son total maximum de points de vie avec ce sort, il perd tout point de vie en trop au bout d'un tour.
+
+Le lanceur ne peut profiter des points de vie supplémentaires accordés par ce sort qu'une seule fois tous les tours, indépendamment du nombre de victimes.
+~
+//NRD: move to 2nd level
+@7241  = ~Rupture hasardeuse de Nahal~
+@7242  = ~Rupture hasardeuse de Nahal
+(Invocation/Évocation)
+
+Niveau : 1
+Portée : Spéciale
+Durée : Spéciale
+Temps d'incantation : spéciale
+Zone d'effet : spéciale
+Jet de sauvegarde : spécial
+
+Ceci est moins un sort qu'une libération d'énergie magique brute. L'énergie magique entoure et imprègne les entropistes. Cet effet est ce qui survient si un entropiste perd le contrôle et permet à cette énergie de se disperser. Il n'y a pas de sort, pas d'intention dans la magie, seulement une manifestation magique pure et aléatoire.
+
+Les entropistes peuvent libérer cette énergie à tout moment, aussi souvent qu'ils le désirent. D'un autre côté, la plupart passent leur carrière entière à apprendre à l'éviter, plutôt que de le déclencher.
+~
+//Spook: one try per victim
+@7251  = ~Hantise~
+@7252  = ~Hantise
+(Illusion/Fantasme)
+
+Niveau : 1
+Portée : 9 mètres
+Durée : 3 rounds
+Temps d'incantation : 1
+Zone d'effet : 1 créature
+Jet de sauvegarde : annule
+
+Un sort de hantise permet au magicien de jouer avec les peurs naturelles pour provoquer chez une créature la vision de quelqu'un ou de quelque chose d'inamical avançant vers elle d'une manière menaçante. Si la créature ne réussit pas un jet de sauvegarde contre les sorts, elle s'enfuit le plus vite et le plus loin possible du magicien. La créature a une pénalité de jet de 1 point par tranche de 2 niveaux d'expérience du lanceur du sort, avec un maximum de 6 points au niveau 12. Ce n'est pas le magicien qui poursuit effectivement la créature en fuite, mais un fantasme issu de son esprit. Dans tous les cas, le sort n'est efficace que contre les créatures d'intelligence 2 et plus, et les morts-vivants ne sont pas affectés.
+
+Toute personne qui a été ciblée par ce sort, qu'elle ai ou non réussi le jet de sauvegarde, se méfiera pendant un certain temps, et ne pourra être affectée par ce sort pendant les 8 prochaines heures.
+~

--- a/TomeAndBlood/lang/french/crafting.tra
+++ b/TomeAndBlood/lang/french/crafting.tra
@@ -1,0 +1,484 @@
+//
+//
+//Grammarsalad TRA strings
+//
+
+
+// Actually, all of this is probably unused...
+
+@115003 = ~Écriture de parchemins~
+@115004 = ~Vous devez avoir un sort mémorisé pour écrire un parchemin. Essayez à nouveau une fois que vous aurez mémorisé au moins un sort.~
+@115005 = ~Vous devez posséder au moins 100 pièces d'or pour écrire un parchemin. Essayez à nouveau quand vous posséderez 100 pièces d'or ou plus.~
+@115006 = ~Sorts de niveau 1 (100 pièces d'or)~
+@115007 = ~Sorts de niveau 2 (200 pièces d'or)~
+@115008 = ~Sorts de niveau 3 (300 pièces d'or)~
+@115009 = ~Sorts de niveau 4 (400 pièces d'or)~
+@115010 = ~Sorts de niveau 5 (500 pièces d'or)~
+@115011 = ~Sorts de niveau 6 (1,000 pièces d'or)~
+@115012 = ~Sorts de niveau 7 (1,500 pièces d'or)~
+@115013 = ~Sorts de niveau 8 (2,500 pièces d'or)~
+@115014 = ~Sorts de niveau 9 (5,000 pièces d'or)~
+@115015 = ~Quitter~
+@115016 = ~Choisir un autre niveau de sort~
+@115017 = ~Écriture de parchemin
+Cette compétence vous permet d'écrire un parchemin pour un sort que vous avez mémorisé en ce moment, à condition de disposer de l'or nécessaire.~
+@115018 = ~Vous devez avoir au moins 100 points d'expérience pour écrire un parchemin. Essayez à nouveau quand vous posséderez l'expérience nécessaire.~
+@115019 = ~Choisir le niveau de sort~
+@115020 = ~Création de baguette~
+@115021 = ~Création de baguette
+Cette compétence vous permet de créer une baguette pour un sort que vous avez mémorisé en ce moment, à condition de disposer de l'or nécessaire. Notez que tous les sorts ne peuvent être liés à une baguette. En général, seuls les sorts offensifs peuvent l'être.~
+@115022 = ~Vous devez posséder au moins 900 pièces d'or pour créer une baguette. Essayez à nouveau quand vous posséderez 900 pièces d'or ou plus.~
+@115023 = ~Création de baguette~
+@115024 = ~Vous devez posséder au moins 75 pièces d'or pour créer une potion. Essayez à nouveau quand vous posséderez 75 pièces d'or ou plus.~
+@115025 = ~Création de potion~
+@115026 = ~Sorts bonus~
+
+// start unused (component 45 arcane crafting is deprecated)
+@115027 = ~Rupture hasardeuse de Nahal~
+// only changes casting time
+@115028 = ~Rupture hasardeuse de Nahal
+(Invocation/Évocation)
+
+Niveau : 1
+Portée : spéciale
+Durée : spéciale
+Temps d'incantation : 5
+Zone d'effet : spéciale
+Jet de sauvegarde : spéciale
+
+
+Ce sort est le dernier recours du mage entropiste. Lorsqu'il le lance, il libère une bouffée d'énergie chaotique dans l'espoir de l'attraper au vol et de la façonner pour obtenir l'effet désiré. C'est en général un échec, mais il se produit toujours quelque chose.
+
+Le mage spécifie le sort qu'il va essayer de simuler avant de commencer son incantation. Le sort simulé doit pouvoir être lancé par le magicien (c'est-à-dire, figurer dans son livre de sort), mais il n'a pas besoin de l'avoir en mémoire. Après tous les préparatifs nécessaires (désignation de la cible et spécification de tous les paramètres requis par le sort simulé), le magicien lance la rupture hasardeuse de Nahal. Une sphère d'énergie magique est créée et il essaye de la modeler. L'effet réel du sort est déterminé aléatoirement.
+
+Comme le mage essaie néanmoins de diriger l'énergie magique, son niveau est additionné au jet qui sert à déterminer l'effet réel du sort. Cela signifie qu'il a de bonnes chances d'obtenir un résultat positif. Malheureusement, la plupart du temps, l'effet obtenu est complètement imprévu et peut varier de positif à complètement catastrophique : pas de réussite sans prise de risques !~
+
+@115029 = ~Bouclier du chaos~
+// removes: it does not stack with improved chaos shield
+@115030 = ~Bouclier du chaos
+(Abjuration)
+
+Niveau : 2
+Portée : personnelle
+Durée : 5 rounds + 1 tour par 5 niveaux
+Temps d'incantation : 2
+Zone d'effet : le lanceur
+Jet de sauvegarde : aucun
+
+Ce sort augmente les probabilités d'obtenir un résultat favorable en cas de hiatus entropique. À chaque fois qu'un jet est fait sur la table, un bonus de 15 est ajouté. Lorsque la rupture hasardeuse est lancée, ce bonus s'ajoute au niveau du mage entropiste.~
+
+@115031 = ~Bouclier majeur du chaos~
+// changes duration (but not in french?), removes "does not stack..."
+@115032 = ~Bouclier majeur du chaos
+(Abjuration)
+
+Niveau : 7
+Portée : personnelle
+Durée : 2 tours
+Temps d'incantation : 7
+Zone d'effet : le lanceur
+Jet de sauvegarde : aucun
+
+Ce sort augmente les probabilités d'obtenir un résultat favorable en cas de hiatus entropique. À chaque fois qu'un jet est fait sur la table, un bonus de 25 est ajouté. Lorsque la rupture hasardeuse est lancée, ce bonus s'ajoute au niveau du mage entropiste. ~
+// end unused
+
+@115033 = ~Baguette de catégorie 1 (900 po)~
+@115034 = ~Baguette de catégorie 2 (1 900 po)~
+@115035 = ~Baguette de catégorie 3 (5 000 po)~
+@115036 = ~Baguette de catégorie 4 (10 000 po)~
+@115037 = ~Baguette de catégorie 5 (15 000 po)~
+
+@115038 = ~Rechargement de baguettes~
+
+@115039 = ~Rechargement de baguettes
+Cette compétence vous permet de recharger des baguettes si vous possédez le sort ou le parchemin nécessaire et l'or requis pour acheter les matériaux spéciaux. Les conditions sur les sorts et parchemins requis pour recharger une baguette sont moins strictes que pour créer une baguette (c'est à dire qu'il est possible de recharger une baguette avec des sorts de niveau moins élevés que ceux pour créer cette baguette).
+Vous ne pouvez pas recharger de baguette si vous en avez plusieurs en votre possession immédiate parce que le conflit dissiperait les énergies magiques.~
+
+@115040 = ~Vous devez posséder au moins 225 pièces d'or pour recharger une baguette. Essayez à nouveau quand vous posséderez 225 pièces d'or ou plus.~
+
+@115041 = ~Choisir une baguette à recharger~
+@115042 = ~Recharger la baguette de projectiles magiques~
+@115043 = ~Choisir quel sort ou parchemin utiliser pour recharger votre baguette~
+@115044 = ~Utiliser un parchemin de Projectile magique~
+@115045 = ~Utiliser un sort de Projectile magique~
+@115046 = ~Recharger une autre baguette~
+// unused @115047 = ~Baguette de sommeil~
+@115048 = ~Baguette d'effroi~
+// unused @115049 = ~Utiliser un parchemin de Hantise~
+// unused @115050 = ~Utiliser un sort de Hantise~
+@115051 = ~Utiliser un parchemin d'Horreur~
+@115052 = ~Utiliser un sort d'Horreur~
+// unused @115053 = ~Utiliser un parchemin de Symbole, terreur~
+// unused @115054 = ~Utiliser un sort de Symbole, terreur~
+@115055 = ~Baguette de convocation de monstres	~
+@115056 = ~Baguette de feu~
+@115057 = ~Baguette de paralysie~
+@115058 = ~Baguette de foudre~
+// unused @115059 = ~Baguette de mort gelée~
+@115060 = ~Utiliser un parchemin de Convocation de monstres I~
+@115061 = ~Utiliser un sort de Convocation de monstres I~
+// unused @115062 -115071
+@115072 = ~Baguette de projectiles magiques : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de projectiles magiques dans votre inventaire.~
+@115073 = ~*Recharge la baguette de projectiles magiques*~
+@115074 = ~Recharger la baguette de sommeil~
+@115076 = ~Utiliser un parchemin de Sommeil~
+@115077 = ~Utiliser un sort de Sommeil~
+@115080 = ~*Recharge la baguette de sommeil*~
+@115082 = ~Baguette de projectiles magiques~
+@115083 = ~Choisir la baguette que vous souhaitez créer~
+@115084 = ~Choisir quel parchemin ou sort vous souhaitez utiliser pour créer votre baguette~
+@115085 = ~Utiliser un parchemin de projectiles magiques~
+@115086 = ~Utiliser un sort de projectiles magiques~
+@115087 = ~Choisir une autre catégorie~
+@115088 = ~Choisir une autre baguette de catégorie 1~
+@115089 = ~Baguette de sommeil~
+@115090 = ~Choisir une autre baguette de catégorie 2~
+@115091 = ~Utiliser un sort de Boule de feu~
+@115092 = ~Choisir une autre baguette de catégorie 3~
+@115095 = ~Utiliser un sort de Feu solaire~
+@115096 = ~Utiliser un sort de Linceul de flammes~
+@115097 = ~Utiliser un sort de Convocation d’un élémentaire de feu~
+@115098 = ~Utiliser un sort de Boule de feu à retardement~
+@115099 = ~Utiliser un sort de Nuage incendiaire~
+@115100 = ~Utiliser un sort de Nuée de météores~
+@115101 = ~Utiliser un parchemin de Boule de feu~
+@115102 = ~Utiliser un parchemin de Flèche enflammée~
+@115103 = ~Utiliser un parchemin de Convocation d’un élémentaire de feu mineur~
+@115104 = ~Choisir la catégorie que vous souhaitez recharger.~
+@115105 = ~Baguette de catégorie 1 (225 po)~
+@115106 = ~Baguette de catégorie 2 (475 po)~
+@115107 = ~Baguette de catégorie 3 (1 250 po)~
+@115108 = ~Baguette de catégorie 4 (2 500 po)~
+@115109 = ~Baguette de catégorie 5 (3 750 po)~
+@115110 = ~Vous devez posséder au moins 475 pièces d'or pour recharger une baguette de catégorie 2. Essayez à nouveau quand vous posséderez 475 pièces d'or ou plus.~
+@115111 = ~Vous devez posséder au moins 1 250 pièces d'or pour recharger une baguette de catégorie 3. Essayez à nouveau quand vous posséderez 1 250 pièces d'or ou plus.~
+@115112 = ~Vous devez posséder au moins 2 500 pièces d'or pour recharger une baguette de catégorie 4. Essayez à nouveau quand vous posséderez 2 500 pièces d'or ou plus.~
+@115113 = ~Vous devez posséder au moins 3 750 pièces d'or pour recharger une baguette de catégorie 5. Essayez à nouveau quand vous posséderez 3 750 pièces d'or ou plus.~
+@115114 = ~Utiliser un parchemin d’Éclair~
+@115115 = ~Utiliser un sort d’Éclair~
+@115116 = ~Utiliser un sort de Convocation de monstres I~
+@115117 = ~Utiliser un parchemin de Convocation de monstres I~
+@115118 = ~Cette baguette mortelle peut lancer un certain nombre de sorts de froid.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Lance de glace
+  Dégâts : 5d6 dégâts de froid
+  Étourdit la cible pendant 3 rounds ; jet de sauvegarde contre les sorts pour annuler
+  Portée : 30 mètres
+  Zone d'effet : 1 créature
+
+- Nuée de boules de neige de Snilloc
+  Dégâts : 4d3 dégâts de froid ; jet de sauvegarde contre les sorts pour demi-dégâts
+  Portée : 12 mètres
+  Zone d'effet : rayon de 4,50 mètres
+
+- Tempête de glace
+  Dégâts : 3d10 dégâts de froid
+  Portée : 12 mètres
+  Zone d'effet : rayon de 4,50 mètres
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+
+@115119 =  ~Cette puissante baguette a été créée par le magicien Hegthen, qui souhaitait se protéger des créatures de feu de son pire ennemi. Il s'en servit souvent au cours du long conflit qui l'opposa à son rival. Après avoir été traqué dix années durant par les séides de son ennemi, Hegthen décida de l'attaquer de front. Il le terrassa au cours de l'un des duels les plus spectaculaires de toute l'histoire de Suzail. Victorieux, il imposa à son rival que le nom de celui-ci soit effacé par magie de l'esprit de tous ceux qui le connaissaient. L'autre accepta, et on ne le connaît plus désormais que sous le nom de Flamme Masquée. Dangereux terroriste, il fut tué par les Dragons Pourpres et Mages de Guerre du Cormyr en 1212 CV.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Lance de glace
+  Dégâts : 5d6 dégâts de froid
+  Étourdit la cible pendant 3 rounds ; jet de sauvegarde contre les sorts pour annuler
+  Portée : 30 mètres
+  Zone d'effet : 1 créature
+
+- Nuée de boules de neige de Snilloc
+  Dégâts : 4d3 dégâts de froid ; jet de sauvegarde contre les sorts pour demi-dégâts
+  Portée : 12 mètres
+  Zone d'effet : rayon de 4,50 mètres
+
+- Tempête de glace
+  Dégâts : 3d10 dégâts de froid
+  Portée : 12 mètres
+  Zone d'effet : rayon de 4,50 mètres
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+@115120 =  ~Baguette de mort gelée~
+
+~Cette baguette mortelle permet de lancer Tempête de glace.
+
+PARAMÈTRES :
+
+Capacités de charge :
+
+Tempête de glace
+  Dégâts : 3d10 de froid
+  Portée : 12 m
+  Zone d’effet : rayon de 9 m
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+@115121 = ~Baguette de mort gelée~
+@115122 = ~Utiliser un sort de Tempête de glace~
+@115123 = ~Utiliser un parchemin de Tempête de glace~
+@115124 = ~Choisir une autre baguette de catégorie 4~
+@115125 = ~Baguette d’armure~
+@115126 = ~Cette baguette, que l'on confond souvent avec une autre portant le même nom, protège son utilisateur à l'aide de sorts. Malheureusement pour son créateur, les trolls sont particulièrement résistants...
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Bouclier : classe d'armure de 4 (2 contre les projectiles) et immunité aux Projectiles magiques
+  Durée : 15 rounds
+  Zone d'effet : l'utilisateur
+
+- Armure fantomatique : classe d'armure de 3
+  Durée : 7 rounds
+  Zone d'effet : l'utilisateur
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+@115127 = ~Utiliser un sort d’Armure spirituelle~
+@115128 = ~Utiliser un parchemin d’Armure spirituelle~
+
+@115129 = ~Utiliser un sort d’Immobilisation des monstres~
+@115130 = ~Utiliser un parchemin d’Immobilisation des monstres~
+
+@115131 = ~Choisir une autre baguette de catégorie 5~
+@115132 = ~Baguette de givre~
+
+@115133 = ~Baguettes de catégorie 6 (25 000 po)~
+@115134 = ~Baguette de Contrecoup~
+@115135 = ~Choisir une autre baguette de catégorie 6~
+@115136 = ~Baguette de métamorphose~
+@115137 = ~Baguette de Métamorphose
+La baguette émet un rayon vert qui porte au maximum à 18 mètres. Une créature touchée par ce rayon doit réussir un jet de sauvegarde contre les baguettes, sous peine d'être métamorphosée en écureuil.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- métamorphose la cible en écureuil (jet de sauvegarde contre les baguettes pour annuler)
+  Portée : 30 mètres
+  Zone d'effet : 1 créature
+  Durée : permanente jusqu'à dissipation
+
+Nécessite : 9 en Intelligence
+
+Poids : 1~
+
+@115138 = ~Utiliser un sort de Cône de froid~
+@115139 = ~Utiliser un parchemin de Cône de froid~
+
+@115140 = ~Utiliser un sort de Perce-magie~
+@115141 = ~Utiliser un parchemin de Perce-magie~
+
+@115142 = ~Utiliser un sort de Métamorphose d'autrui~
+@115143 = ~Utiliser un parchemin de Métamorphose d'autrui ~
+@115144 = ~Baguette de Malédiction~
+
+@115145 = ~Cette baguette rend instantanément aveugles, sourds et muets les adversaires... mais le réel danger de cet objet vient du fait que tout le monde peut l'utiliser !
+
+PARAMÈTRES :
+
+Capacités de charge :
+- lance Cécité, Surdité et Silence sur la cible (jet de sauvegarde contre les sorts pour annuler tous les effets)
+  Durée : 1 tour
+  Zone d'effet : 1 créature
+
+Poids : 1~
+
+@115146 = ~Baguette de corrosion~
+
+@115147 = ~Trois magiciens ont fabriqué cette baguette à partir de matériaux qu'ils avaient en leur possession et d'ingrédients faciles à se procurer. Otterly le Rotond, Mabdek de la Septième Étoile et Yrgon le Crétin ont créé cette baguette dans le seul but de la vendre. Leur objectif à long terme était la construction d'un grand centre de recherches basé sur les plans de la Guilde de la Nature de Myth Drannor. Leur baguette connut davantage de succès que leur centre...
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Brume mortelle
+  Dégâts : inflige 4 points d'acide le premier round, 8 points le deuxième et 16 points le troisième
+  Spécial : le mouvement est ralenti de 50 % à l'intérieur de la zone et les cibles doivent réussir un jet de sauvegarde à chaque round contre les sorts ou recevoir un malus de -2 à la force et la dextérité pendant le round
+  Portée : champ visuel de l'utilisateur
+  Durée : 15 rounds
+  Zone d'effet : rayon de 3,60 mètres
+
+- Tempête acide
+  Dégâts : 1d4 points d'acide pendant 3 rounds, 1d6 points d'acide pendant les 3 rounds suivants et 1d8 points d'acide pendant les rounds restants ; jet de sauvegarde contre les sorts pour demi-dégâts
+  Portée : champ visuel de l'utilisateur
+  Durée : 30 rounds
+  Zone d'effet : rayon de 3,60 mètres
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+
+@115148 = ~Quand elle est activée, cette baguette lance soit Brume mortelle soit Tempête acide.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Brume mortelle
+  Dégâts : inflige 4 points d'acide le premier round, 8 points le deuxième et 16 points le troisième
+  Spécial : le mouvement est ralenti de 50 % à l'intérieur de la zone et les cibles doivent réussir un jet de sauvegarde à chaque round contre les sorts ou recevoir un malus de -2 à la force et la dextérité pendant le round
+  Portée : champ visuel de l'utilisateur
+  Durée : 15 rounds
+  Zone d'effet : rayon de 3,60 mètres
+
+- Tempête acide
+  Dégâts : 1d4 points d'acide pendant 3 rounds, 1d6 points d'acide pendant les 3 rounds suivants et 1d8 points d'acide pendant les rounds restants ; jet de sauvegarde contre les sorts pour demi-dégâts
+  Portée : champ visuel de l'utilisateur
+  Durée : 30 rounds
+  Zone d'effet : rayon de 3,60 mètres
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+
+@115149 = ~Quand elle est activée, cette baguette lance Brume mortelle .
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Brume mortelle
+  Dégâts : inflige 4 points d'acide le premier round, 8 points le deuxième et 16 points le troisième
+  Spécial : le mouvement est ralenti de 50 % à l'intérieur de la zone et les cibles doivent réussir un jet de sauvegarde à chaque round contre les sorts ou recevoir un malus de -2 à la force et la dextérité pendant le round
+  Portée : champ visuel de l'utilisateur
+  Durée : 15 rounds
+  Zone d'effet : rayon de 3,60 mètres
+
+Nécessite : 9 en intelligence
+
+Poids : 1~
+
+@115150 = ~Baguettes de catégorie 7 (50 000 po)~
+
+@115151 = ~Utiliser un sort de Tempête acide~
+@115152 = ~Utiliser un parchemin de Tempête acide~
+@115153 = ~Choisir une autre baguette de catégorie 7~
+@115154 = ~Baguette de Nuage Mortel~
+// changes save and radius
+@115155 = ~Baguette de Nuage Mortel
+Cette baguette émet une bulle de vapeur qui file vers sa cible et explose en un nuage de gaz mortel qui remplit une zone de 4,50 mètres de rayon environ. Ce nuage tue instantanément toute créature de 4 DV ou moins sans jet de sauvegarde. Toute créature de 5 ou 6 DV a droit à un jet de sauvegarde pour ne pas mourir. Les créatures de plus de 6 DV prennent 1-10 de dégâts à chaque round dans le nuage. Il se dissipe au bout d'environ un tour.
+
+PARAMÈTRES :
+
+Capacités de charge :
+- Nuage mortel
+  Dégâts : 1d10 du poison par round
+  Spécial : les créatures de 1 à 4 dés de vie meurent instantanément (pas de jet de sauvegarde), celles qui ont 5 ou 6 dés de vie doivent réussir un jet de sauvegarde contre les sorts sous peine de mourir instantanément.
+  Portée : 18 mètres
+  Zone d'effet : 4,50 mètres de rayon
+  Durée : 1d4 tours
+
+Nécessite : 9 en Intelligence
+
+Poids : 1~
+
+@115156 = ~Utiliser un sort de Nuage mortel~
+@115157 = ~Utiliser un parchemin de Nuage mortel~
+@115158 = ~Baguettes de catégorie 6 (6 250 po)~
+@115159 = ~Baguettes de catégorie 7 (12 500 po)~
+@115160 = ~Vous devez posséder au moins 6 250 pièces d'or pour recharger une baguette de catégorie 6. Essayez à nouveau quand vous posséderez 6 250 pièces d'or ou plus.~
+@115161 = ~Vous devez posséder au moins 12 500 pièces d'or pour recharger une baguette de catégorie 7. Essayez à nouveau quand vous posséderez 12 500 pièces d'or ou plus.~
+@115162 = ~Baguette d’effroi : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette d’effroi dans votre inventaire.~
+@115163 = ~Recharger la baguette d’effroi~
+@115164 = ~*Recharge la baguette d’effroi*~
+@115165 = ~Baguette de feu : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de feu dans votre inventaire.~
+@115166 = ~Recharger la baguette de feu~
+@115167 = ~*Recharge la baguette de feu*~
+@115168 = ~Recharger la baguette de foudre~
+@115169 = ~Baguette de foudre : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de foudre dans votre inventaire.~
+@115170 = ~Recharger la baguette de convocation de monstres~
+@115171 = ~Baguette de convocation de monstres : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de convocation de monstres dans votre inventaire.~
+@115172 = ~Utiliser un parchemin de Boule de feu~
+@115173 = ~Utiliser un parchemin d’Éclair~
+@115174 = ~Utiliser un sort d’Éclair~
+@115175 = ~*Recharge la baguette de foudre*~
+@115176 = ~*Recharge la baguette de convocation de monstres*~
+@115177 = ~Baguette de mort gelée : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de mort gelée dans votre inventaire.~
+@115178 = ~Recharger la baguette de mort gelée~
+@115179 = ~*Recharge la baguette de mort gelée*~
+@115180 = ~Recharger la baguette de mort gelée~
+@115181 = ~Baguette d’armure : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette d’armure dans votre inventaire.~
+@115182 = ~Utiliser un parchemin d’Armure spirituelle~
+@115183 = ~Utiliser un sort d’Armure spirituelle~
+@115184 = ~*Recharge la baguette d’armure*~
+@115185 = ~Recharger la baguette de métamorphose~
+@115186 = ~Baguette de métamorphose : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de métamorphose dans votre inventaire.~
+@115187 = ~Utiliser un parchemin de Métamorphose d’autrui~
+@115188 = ~Utiliser un sort de Métamorphose d’autrui~
+@115189 = ~*Recharge la baguette de métamorphose*~
+@115190 = ~Recharger la baguette de paralysie~
+@115191 = ~Baguette de paralysie : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de paralysie dans votre inventaire.~
+@115192 = ~Utiliser un sort d’Immobilisation des monstres~
+@115193 = ~Utiliser un parchemin d’Immobilisation des monstres~
+@115194 = ~Recharger la baguette de givre~
+@115195 = ~Baguette de givre : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de givre dans votre inventaire.~
+@115196 = ~Utiliser un parchemin de Cône de froid~
+@115197 = ~Utiliser un sort de Cône de froid~
+@115198 = ~Recharger la baguette de nuage mortel~
+@115199 = ~Baguette de nuage mortel : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de nuage mortel dans votre inventaire.~
+@115200 = ~Utiliser un parchemin de Nuage mortel~
+@115201 = ~Utiliser un sort de Nuage mortel~
+@115202 = ~*Recharge la baguette de givre*~
+@115203 = ~*Recharge la baguette de paralysie*~
+@115204 = ~*Recharge la baguette de nuage mortel*~
+@115205 = ~*Recharge la baguette de mort gelée*~
+@115206 = ~Recharger la baguette de contrecoup~
+@115207 = ~Baguette de contrecoup : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de contrecoup dans votre inventaire.~
+@115208 = ~Utiliser un parchemin de Perce-magie~
+@115209 = ~Utiliser un sort de Perce-magie~
+@115210 = ~*Recharge la baguette de contrecoup*~
+@115211 = ~Recharger la baguette de malédiction~
+@115212 = ~Baguette de malédiction : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de malédiction dans votre inventaire.~
+@115213 = ~ Utiliser un parchemin de Mot de pouvoir : silence~
+@115214 = ~Utiliser un sort de Mot de pouvoir : silence~
+@115215 = ~*Recharge la baguette de malédiction*~
+@115216 = ~Recharger la baguette de corrosion~
+@115217 = ~Baguette de corrosion : Vous ne pouvez recharger une baguette si vous disposez de plusieurs exemplaires du même type de baguette dans votre inventaire. Annulez puis essayez à nouveau quand vous n’aurez qu’une seule baguette de corrosion dans votre inventaire.~
+@115218 = ~Utiliser un parchemin de Tempête acide~
+@115219 = ~Utiliser un sort de Tempête acide~
+@115220 = ~*Recharge la baguette de corrosion*~
+
+@115224 = ~Utiliser un parchemin de Brume mortelle~
+@115225 = ~Utiliser un sort de Brume mortelle~
+@115226 = ~Vous devez posséder au moins 50 pièces d'or pour écrire un parchemin. Essayez à nouveau quand vous posséderez 50 pièces d'or ou plus.~
+@115227 = ~Écriture de parchemin efficiente~
+@115228 = ~Vous devez posséder au moins 450 pièces d'or pour créer une baguette. Essayez à nouveau quand vous posséderez 450 pièces d'or ou plus.~
+@115229 = ~Vous devez posséder au moins 115 pièces d'or pour recharger une baguette. Essayez à nouveau quand vous posséderez 115 pièces d'or ou plus.~
+@115230 = ~Création de baguette efficiente~
+@115231 = ~Rechargement de baguette efficient~
+
+@115232 = ~Potions de catégorie 1 (75 po)~
+@115233 = ~Potion d’infravision~
+@115234 = ~Potion de force~
+@115235 = ~Potion de résistance au feu~
+@115236 = ~Potion d’invisibilité~
+@115237 = ~Huile de feux ardents~
+@115238 = ~Potion d'agilité~
+@115239 = ~Potion de résistance au froid~
+@115240 = ~Huile de rapidité~
+@115241 = ~Potion de blocage de magie~
+@115242 = ~Potion de résistance à la magie~
+@115243 = ~Potion of Potion de défens~
+@115244 = ~Potion d'isolation~
+@115245 = ~Potion d'invulnérabilité~
+@115246 = ~Potion d'haleine ardente~
+@115247 = ~Potion de rétrovision~
+@115248 = ~Potions de catégorie 2 (300 po)~
+@115249 = ~Potions de catégorie 3 (400 po)~
+
+@115250 = ~Potions de catégorie 4 (500 po)~
+@115251 = ~Potions de catégorie 5 (1 000 po)~
+@115252 = ~Potions de catégorie 6 (1 500 po)~
+@115253 = ~Choisir une autre catégorie~
+@115254 = ~Création de Potion
+Vous pouvez créer des potions, à condition de disposer du bon sort et d’assez d’or.~
+@115255 = ~Création d’objet~
+@115256 = ~Création d’objet
+Vous pouvez créer et recharger des objets, à condition de disposer du bon sort et d’assez d’or.~

--- a/TomeAndBlood/lang/french/familiars.tra
+++ b/TomeAndBlood/lang/french/familiars.tra
@@ -1,0 +1,157 @@
+
+@8011  = ~Pseudo-dragon~
+@8012  = ~Pseudo-dragon : c'est un minuscule parent lointain des vrais dragons. Le pseudo-dragon peut lancer Soin des blessures légères et Flou et peut aussi utiliser une « arme de souffle » colorée qui imite le sort Vapeurs colorée une fois tous les 3 tours (à un niveau élevé, le sort de Flou s'améliore pour devenir un effet d'Invisibilité majeure). Ils peuvent attaquer deux fois par round et, si leurs griffes sont petites, elles sont enduites d'un stupéfiant léger qui peut rendre la cible somnolente et maladroite (imite les effets du sort Lenteur, pendant 2 rounds).
+
+Quand ce familier est à proximité de son maître, le maître régénère 1 point de vie par round.
+
+Comme les pseudo-dragons volent, ils sont insensibles aux effets de Glisse, d'enchevêtrement, de Toile et autres sorts similaires. Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8013  = ~Pseudo-dragon~
+@8014  = ~Pseudo-dragon : Les pseudo-dragons sont plutôt intelligents. Même s'ils sont petits, ils sont rapides et assez bien protégés. Ils ne font pas beaucoup de dégâts au combat, mais leurs griffes magiques sont capables de rendre certains ennemis inconscients. Ils sont aussi relativement résistants aux sorts.
+
+Quand ce familier est à proximité de son maître, le maître récupère lentement sa santé.
+
+Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+//unused
+@8015  = ~Chien~
+//unused
+@8016  = ~Chien : ...~
+@8017  = ~Furet~
+@8018  = ~Furet : Ces animaux sont intelligents et espiègles et, bien qu'attendrissants, peuvent à l'occasion émettre une odeur nauséabonde. Au combat, ils peuvent attaquer deux fois par round et peuvent émettre une aura écœurante de courte portée qui peut amener les ennemis proches à avoir des hauts-le-cœur, provoquant une pénalité de 2 points aux jets d'attaque et à la classe d'armure, ainsi qu'un risque d'échec des sorts de 30 %.
+
+Les furets sont aussi furtifs et peuvent remplir le rôle de pickpocket pour aider leur maître.
+
+Quand ce familier est à proximité de son maître, le maître bénéficie d'un bonus de 1 point à la constitution.
+
+Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8019  = ~Lapin~
+@8020  = ~Lapin : Même si le lapin n'est pas un combattant impressionnant, il est très habile pour éviter les blessures. Les lapins ont une résistance de 25 % aux attaques élémentaires et peuvent, une fois par tour, creuser dans le sol et se diriger sans obstacle vers un endroit sûr (en pratique, ceci ressemble à la faculté Pas de l'ombre des Maîtres de l'ombre). Les lapins ont aussi un sens aiguisé du danger et peuvent utiliser très efficacement leurs museaux et leurs oreilles sensibles pour repérer les pièges.
+
+Quand ce familier est à proximité de son maître, le maître est immunisé contre les sorts de Lenteur et autres effets similaires.
+
+Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8021  = ~Chat~
+@8022  = ~Chat : Le chat noir est un familier traditionnel des mages et est très utile comme éclaireur. Ils peuvent se déplacer sans être vus, à la manière un maître voleur, et peuvent rester discrets même devant des sorts qui dévoilent les créatures invisibles (mais les créatures qui ont une faculté naturelle pour voir les êtres cachés et invisibles peuvent malgré tout percevoir un chat).
+
+Quand ce familier est à proximité de son maître, le maître bénéficie d'un bonus de 1 point à la dextérité.
+
+Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8023  = ~Diablotin~
+@8024  = ~Diablotin : ~
+@8025  = ~Araignée~
+@8026  = ~Araignée : Une araignée peut faire un familier pratique, mais peut-être un peu repoussant, pour un mage qui ne souffrirait pas d'arachnophobie. Les araignées sont efficaces au combat, surtout contre les lanceurs de sorts grâce au venin qu'elles injectent et qui peut infliger 3 points de dégâts sur 6 secondes. Cette espèce-ci d'araignée, de grande taille, est capable, une fois tous les 5 rounds, de projeter un amas gluant de toiles sur un ennemi, qui risque d'être maintenu en place pendant 3 rounds s'il échoue à son jet de sauvegarde.
+
+Quand ce familier est à proximité de son maître, le maître a une chance supplémentaire d'éviter les sorts ou les effets qui inflige des dégâts de poison.
+
+Les araignées ne peuvent être immobilisées par les toiles ou autres effets similaires. Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8027  = ~Méphite~
+@8028  = ~Méphite : ...~
+@8029  = ~Quasit~
+@8030  = ~Quasit : ...~
+@8031  = ~Rat~
+@8032  = ~Rat : Les rats sont des créatures étonnement intelligentes et sociables, en particulier quand ils sont améliorés par ce sort. Une fois tous les 3 tours, ce familier peut appeler 1d6 camarades rats pour l'aider au combat. Même domestiqués, les rats sont toujours associés aux ordures et aux maladies, ce qui peut être utile contre leurs ennemis. À chaque fois qu'une cible est touchée, elle peut contracter une maladie et subir une brève période de faiblesse et un risque d'échec des sorts de 25 %/
+
+Quand ce familier est à proximité de son maître, le maître bénéficie d'un bonus de 1 point à l'intelligence.
+
+Comme pour tous les familiers, leur connexion avec leur maître les immunise contre la pétrification et les effets d'absorption de niveau.
+~
+@8111  = ~Puanteur écœurante~
+@8113  = ~Attaque de toile~
+@8115  = ~Horde de rats~
+@8201  = ~Vous pouvez infuser votre familier avec un des sorts suivants. Attention, ceci réduira le nombre de sorts que vous pouvez lancer et ce changement est permanent !~
+@8202  = ~Ne pas transférer de sort vers le familier pour le moment~
+@8203  = ~Infuser le familier~
+@8204  = ~Infuser le familier avec ce sort~
+@8205  = ~Choisir un autre sort~
+@8206  = ~Infuser le familier
+
+Cette faculté permet d'accorder au familier la capacité de lancer des sorts. Les sorts sont choisis parmi ceux connus du lanceur. Quand le lanceur est de niveau 1, un sort de niveau 1 peut être transféré. Au niveau 3, il peut transférer un sort de niveau 2 au plus, un sort de niveau 3 au plus à partir du niveau 6, un sort de niveau 4 ou plus à partir du niveau 10 et un sort de niveau 5 ou plus à partir du niveau 15.
+
+Une fois que le familier est infusé avec la capacité à lancer un sort il peut lancer ce sort une fois pas rencontre. À chaque fois qu'un familier est infusé de la sorte, le choix est permanent et ne peut être annulé.
+~
+//
+// familiars (tra refs = BG2 str refs)
+//
+@58296 = ~La petite créature semblable à un dragon ronronne d'un air perplexe en écarquillant les yeux. Puis recule nerveusement vers <CHARNAME>. Visiblement, elle ne souhaite pas vous parler.~
+@58297 = ~La petite créature semblable à un dragon bat des ailes joyeusement, en vous regardant avec des yeux changeants, presque kaléidoscopiques. « Vous voulez quelque chose ? » elle cherche à attirer votre attention en remuant la queue.~
+@58298 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58299 = ~*la caresser et jouer avec elle*~
+@58300 = ~Tu n'aurais pas un conseil à me donner, par hasard ?~
+@58301 = ~Comment vas-tu ? Tout va bien ?~
+@58302 = ~Ses yeux s'éclairent et il saute dans vos bras, prêt à être rangé dans vos affaires, où il peut dormir et parfois sortir la tête à l'extérieur.~
+@58303 = ~Le dragon roucoule de contentement, ses yeux multicolores tourbillonnants alors que vous caressez sa peau chaude et tannée. « Vous êtes très gentil avec moi, mon maître », ronronne-t-il.~ ~Le dragon roucoule de contentement, ses yeux multicolores tourbillonnants alors que vous caressez sa peau chaude et tannée. « Vous êtes très gentille avec moi, ma maîtresse », ronronne-t-il.~
+@58304 = ~Non, tout va bien. Continuons.~
+@58866 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58305 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58306 = ~Tu n'aurais pas un conseil à me donner, par hasard ?~
+@58307 = ~Comment vas-tu ? Tout va bien ?~
+@58308 = ~Alors continuons.~
+@59477 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58309 = ~Le familier tend son cou et regarde vers l'arrière dans votre direction d'un air un peu perplexe. « Vous voulez *me* demander conseil, ô maître ? »~ ~Le familier tend son cou et regarde vers l'arrière dans votre direction d'un air un peu perplexe. « Vous voulez *me* demander conseil, ô maîtresse ? »~
+@58310 = ~Il observe l'obscurité pendant un long moment avant de tourner de nouveau son regard vers vous. « Quittons ce sombre endroit, maître. Tel est mon conseil. »~ ~Il observe l'obscurité pendant un long moment avant de tourner de nouveau son regard vers vous. « Quittons ce sombre endroit, maîtresse. Tel est mon conseil. »~
+@58311 = ~Le dragon regarde autour de lui d'un air perplexe avant de tourner de nouveau son regard vers vous. « Nous allons à l'endroit des pauvres ? Les bas quartiers, maître ? Je ne sais pas. »~ ~Le dragon regarde autour de lui d'un air perplexe avant de tourner de nouveau son regard vers vous. « Nous allons à l'endroit des pauvres ? Les bas quartiers, maîtresse ? Je ne sais pas. »~
+@58312 = ~Le petit dragon pousse un petit rire mélodieux. « Vous devez trouver de l'or, mon maître. Des pièces par milliers, suffisamment pour répondre à vos questions. »~ ~Le petit dragon pousse un petit rire mélodieux. « Vous devez trouver de l'or, ma maîtresse. Des pièces par milliers, suffisamment pour répondre à vos questions. »~
+@58313 = ~Il a presque l'air de froncer les sourcils, ses yeux teintés d'un jaune sinistre avant de continuer. « Je ne sais pas, mon maître. Vous devez poursuivre ces tâches, n'est-ce pas ? »~ ~Il a presque l'air de froncer les sourcils, ses yeux teintés d'un jaune sinistre avant de continuer. « Je ne sais pas, ma maîtresse. Vous devez poursuivre ces tâches, n'est-ce pas ? »~
+@58314 = ~Il médite pendant un long moment, remuant sa queue distraitement avant de reprendre. « Nous devons tout faire pour arrêter ce magicien. Mettez-vous en sécurité avec la petite sœur. Tel est mon conseil. »~
+@58315 = ~Il regarde autour de lui pendant un certain temps. La peur se lit dans ses yeux tandis que sa queue s'enroule autour de son ventre. « Nous devons partir d'ici au plus vite, maître, d'accord ? »~ ~Il regarde autour de lui pendant un certain temps. La peur se lit dans ses yeux tandis que sa queue s'enroule autour de son ventre. « Nous devons partir d'ici au plus vite, maîtresse, d'accord ? »~
+@58316 = ~Il médite pendant un moment et ses yeux s'éclairent. « Nous devons trouver la cité elfique sacrée, mon maître. Votre magicien s'y trouve, j'en ai la conviction. »~ ~Il médite pendant un moment et ses yeux s'éclairent. « Nous devons trouver la cité elfique sacrée, ma maîtresse. Votre magicien s'y trouve, j'en ai la conviction. »~
+@58317 = ~Il grogne de façon menaçante, mais pas à votre attention. Il remue sa queue plusieurs fois malicieusement. « Le magicien, maître. C'est lui qui doit mourir et vous qui devez vivre. »~ ~Il grogne de façon menaçante, mais pas à votre attention. Il remue sa queue plusieurs fois malicieusement. « Le magicien, maîtresse. C'est lui qui doit mourir et vous qui devez vivre. »~
+@58318 = ~Le dragon remue la queue et vous regarde avec intérêt. « Tant que vous irez bien, maître, tout ira bien pour moi aussi. »~ ~Le dragon remue la queue et vous regarde avec intérêt. « Tant que vous irez bien, maîtresse, tout ira bien pour moi aussi. »~
+@58319 = ~« Mais puisque vous demandez, je prendrais bien un en-cas. Peut-être un bel écureuil. Ou une tarte... oooh, oui, j'adore les tartes ! »~
+@58320 = ~« Je suis... quand même un peu blessé, maître. Les blessures me brûlent et je saigne. Ce n'est pas très... agréable. »~ ~« Je suis... quand même un peu blessé, maîtresse. Les blessures me brûlent et je saigne. Ce n'est pas très... agréable. »~
+@58321 = ~« Je... je suis grièvement blessé, maître ! Je ne veux pas mourir, papa ! Je veux rester avec vous. » Le dragon gémit et enroule sa queue autour de votre jambe.~ ~« Je... je suis grièvement blessé, maîtresse ! Je ne veux pas mourir, maman ! Je veux rester avec vous. » Le dragon gémit et enroule sa queue autour de votre jambe.~
+@58322 = ~« J'aime beaucoup voyager avec vous, ô maître. Vous auriez une pomme ? Je pourrais la faire rôtir et ensuite la manger. C'est très bon, les pommes ! »~ ~« J'aime beaucoup voyager avec vous, ô maîtresse. Vous auriez une pomme ? Je pourrais la faire rôtir et ensuite la manger. C'est très bon, les pommes ! »~
+@58323 = ~« Je reste ébahi quand je pense à tous les lieux que j'ai vus à vos côtés. Tout est si merveilleux et coloré ! Le monde entier est-il fait ainsi, maître ? »~ ~« Je reste ébahi quand je pense à tous les lieux que j'ai vus à vos côtés. Tout est si merveilleux et coloré ! Le monde entier est-il fait ainsi, maîtresse ? »~
+@58324 = ~« Je me sens merveilleusement bien, mon maître. Ma peau est propre et je suis prêt à vous aider contre tout danger ! »~ ~« Je me sens merveilleusement bien, ma maîtresse. Ma peau est propre et je suis prêt à vous aider contre tout danger ! »~
+@58325 = ~Le dragon remue la queue d'un air satisfait et regarde le chemin devant vous. « Comme vous le souhaitez, ô mon maître. »~ ~Le dragon remue la queue d'un air satisfait et regarde le chemin devant vous. « Comme vous le souhaitez, ô ma maîtresse. »~
+@58867 = ~Ses yeux s'éclairent et il saute dans vos bras, prêt à être rangé dans vos affaires, où il peut dormir et parfois sortir sa tête à l'extérieur.~
+@58356 = ~La petite créature vous regarde avec méfiance. Après vous avoir examinés quelques instants, elle offre son dos à vos yeux en se dirigeant vers <CHARNAME>.~
+@58357 = ~Le familier soupire, le nez tremblant de curiosité, et lève ses yeux noirs. « Et maintenant, <PRO_MANWOMAN> ? J'ai faim. Je veux être soigné et nourri. »~
+@58358 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58360 = ~*caresser le familier*~
+@58383 = ~Tu n'aurais pas un conseil à me donner, par hasard ?~
+@58384 = ~Comment vas-tu ? Tout va bien ?~
+@58873 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@59804 = ~Donne-moi tout ce que tu as chapardé, tu veux bien ?~
+@58385 = ~Plus tard, peut-être. Continuons.~
+@58359 = ~Le familier examine le groupe, puis rampe à l'intérieur. « Très bien. Il vaut mieux que tu me portes. Mais ne me cogne pas partout cette fois. »~
+@58361 = ~« Aaaahhh... » Le familier ferme à demi les yeux de contentement, un large sourire s'inscrivant sur son visage. « Oui, ça fait du bien. Un repas ferait du bien également. »~
+@58362 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@58363 = ~Tu n'aurais pas un conseil à me donner, par hasard ?~
+@58373 = ~Comment vas-tu ? Tout va bien ?~
+@59479 = ~Approche. Je veux te prendre pour te mettre dans mon sac où tu seras plus en sécurité.~
+@59812 = ~Donne-moi tout ce que tu as chapardé, tu veux bien ?~
+@58381 = ~Alors continuons.~
+@58364 = ~L'animal vous regarde, presque étonné. « Moi ? J'ai bien quelques idées que j'aimerais partager, mais t'intéresseront-elles vraiment, <PRO_MANWOMAN> ? »~
+@58365 = ~Le familier scrute les ténèbres et se retourne en haussant les épaules. « Je dirais qu'il faut remonter à la surface, <PRO_MANWOMAN>. Il y a plus de nourriture là-haut. »~
+@58366 = ~Il examine les environs, détaillant les habitants et les animaux de la ville, puis se retourne enfin, presque étonné. « Quoi ? Un conseil ? Euh... non. Je n'ai pas de conseil. »~
+@58367 = ~Le petit animal réfléchit quelques instants et se retourne, vous présentant son arrière-train. Apparemment, il n'avait plus envie de penser.~
+@58368 = ~Il réfléchit un long moment avant de décrocher en bâillant, les yeux fixés dans le vide. « Donne-moi à manger, et fais-moi encore des câlins. Voilà mon conseil. »~
+@58369 = ~Voyons voir... le sorcier se cache derrière toutes tes épreuves, C'est bien ça ? Alors c'est facile, <PRO_MANWOMAN>. Trouve-le, tue-le et tes ennuis seront terminés. Maintenant, tu vas me nourrir, hein ?~
+@58370 = ~Il regarde autour de lui, les oreilles repliées sur sa tête dans un réflexe de peur. « Ici... je suis de la nourriture. Je n'aime pas cet endroit. On devrait aller ailleurs. »~
+@58371 = ~« Hmmm. La cité des elfes abrite l'arbre de vie, <PRO_MANWOMAN>, une chose merveilleuse liée à tout ce qui est naturel. Tu dois trouver la ville et l'arbre. Voilà mon conseil. »~
+@58372 = ~Alors qu'il réfléchit, ses yeux rougeoient d'une lueur de férocité inhabituelle. « Il n'y a qu'une seule solution, <PRO_MANWOMAN>. Si tu veux survivre, le sorcier doit mourir. Il en est ainsi. »~
+@58374 = ~Il vous regarde de ses yeux sombres, semblant heureux d'être près de vous, puis soupire et regarde au loin un instant. « On est proches, toi et moi. Si tu vas bien, moi aussi. »~
+@58375 = ~« Je souffre cependant de quelques blessures insignifiantes. Je suis renforcé par ta force supérieure à la mienne, mais si tu pouvais traiter mes blessures cela me ferait bien plaisir. »~
+@58376 = ~« Je suis cependant moi-même sérieusement blessé. Je saigne, <PRO_MANWOMAN>. Je pourrais y survivre... ou pas. Nous verrons. »~
+@58377 = ~« Mais puisque tu me le demandes, je suis habité d'une envie irrésistible de nourriture. Procure-m'en un peu et je te permettrai de me caresser un peu plus longtemps. »~
+@58378 = ~« Et je pense que tu fais un bon compagnon de voyage. Je suis satisfait des progrès que nous avons faits. Peut-être resterai-je avec toi pour encore un moment, nous verrons. »~
+@58379 = ~Le petit animal semble chercher quelque chose à dire, mais son attention est attirée par autre chose. Il s'éloigne en dandinant de la queue.~
+@58380 = ~« Tout va comme il faut, <PRO_MANWOMAN>. Pourquoi ? Tu ne te sens pas bien ? Tu ne vas pas tomber malade et me laisser orphelin, n'est-ce pas <PRO_MANWOMAN> ? Si tu meurs cela me chagrinera. Pour un temps. »~
+@58382 = ~Le familier soupire et tourne des yeux désintéressés vers le chemin devant vous. « Je préférerais choisir notre chemin moi-même, mais tu vas sûrement te montrer têtu à ce sujet. »~ ~Le familier soupire et tourne des yeux désintéressés vers le chemin devant vous. « Je préférerais choisir notre chemin moi-même, mais tu vas sûrement te montrer têtue à ce sujet. »~
+@58874 = ~Le familier regarde votre sac pendant un instant puis se glisse à l'intérieur à contrecœur. « Très bien. Il est préférable que vous me transportiez. Cependant ne me cognez pas trop partout cette fois-ci. »~
+@58875 = ~Le familier regarde votre sac pendant un instant puis se glisse à l'intérieur à contrecœur. « Très bien. Il est préférable que vous me transportiez. Cependant ne me cognez pas trop partout cette fois-ci. »~
+@59805 = ~Le familier vous regarde avec méfiance. « Mais quand je prend quelque chose, après, c'est à moi. »~
+@59806 = ~Peu importe. Donne-moi ça.~
+@59807 = ~Allez ! s'il te plaît ! Je te donnerai à manger et je te caresserai...~
+@59808 = ~Oh, tant pis, alors.~
+@59809 = ~Le petit animal roule des yeux et soupire de manière irritée. « Très bien. Mais tu es très cruel avec moi, tu sais. »~
+@59810 = ~Le petit animal remue sa queue en méditant. « Bon... peut-être... Mais j'espère que vous tiendrez parole. *soupire* Oh après tout. J'aime bien me faire prier. »~
+@59811 = ~« Bon, je l'ai bien mérité, après tout ! »~
+@59813 = ~*soupire* « Très bien. Mais ne va pas croire que quelques caresses suffiront, la prochaine fois ! »~
+@58359 = ~Le familier inspecte votre sac, puis se faufile à l'intérieur à contrecœur. « Très bien. Il vaut mieux que vous me portiez. Mais évitez de me cogner partout, cette fois. »~

--- a/TomeAndBlood/lang/french/setup.tra
+++ b/TomeAndBlood/lang/french/setup.tra
@@ -1,0 +1,704 @@
+@1 = ~Ce composant n'est pas disponible pour Baldur's Gate, Icewind Dale ou Icewind Dale 2.~
+@2 = ~Ce composant n'est disponible que pour les jeux Enhanced Edition.~
+@3 = ~Ce composant necessite le moteur ameliore (Enhanced) v2.0 ou ulterieur.~
+//arcane crafting ignored when 5E is installed
+@4 = ~ignore, parce que~
+//unused
+@5 = ~Ajustement de sorts profanes~
+//unused
+@6 = ~Kits profanes, nouveaux et revises~
+//unused
+@7 = ~Mechanics Tweaks (crafting, sequencers, cantrips, familiars, ability bonuses)~
+//unused
+@10 = ~Core Revisions~
+@11 = ~Re-equilibrage des ecoles de magie~
+@12 = ~Re-equilibrage des ecoles profanes opposees~
+@1201 = ~Pas d'ecoles opposees~
+@1202 = ~ecoles opposees de style IWD~
+@1203 = ~ecoles opposees de style BG2~
+@1204 = ~ecoles opposees papier (PnP)~
+@13 = ~Revision des clones illusoires~
+@14 = ~Revision d'Invisibilite et de Vision veritable~
+@15 = ~Revision de Hate et d'Action libre~
+@16 = ~Sort Identification ameliore (utilisable par les Arcanistes et les Ensorceleurs multiclasses)~
+@20 = ~Revision des Disciples du Dragon~
+@25 = ~Kit d'ensorceleur : Magus~
+//unused
+@27 = ~Sorcerer: Arcanist~
+//unused
+@29 = ~Sorcerer: Wild Sorcerer~
+@31 = ~Kit d'ensorceleur : Ame favorite~
+@33 = ~Kit d'ensorceleur : Disciple sylvain~
+@35 = ~Kit d'ensorceleur : Disciple revenant~
+@37 = ~Kit d'ensorceleur : Disciple amorphe~
+@40 = ~Revision des specialistes~
+@45 = ~Artisanat profane~
+@48 = ~Lancer de sort en armure pour les bardes~
+@50 = ~Revision de la  Metamagie~
+@51 = ~Metamagie innee, apprise automatiquement par tout le monde~
+@52 = ~Metamagie innee, apprise automatiquement, mais pas par les ensorceleurs~
+@53 = ~Metamagie innee, apprise depuis les parchemins ou a la generation de personnage~
+@54 = ~Metamagie innee, apprise depuis les parchemins SEULEMENT (pas pour les ensorceleurs)~
+@55 = ~Sorts de metamagie, remplissage gratuit des sequenceurs (utilisable pat les arcanistes et les ensorceleurs multiclasses)~
+@60 = ~Tours de magie~
+@61 = ~Tours de magie innes~
+@62 = ~Tours de magie de niveau 1~
+@63 = ~Baguette de tour de magie~
+@66 = ~Sort de Familier inne~
+@67 = ~Choisir son familier~
+@68 = ~Le mod de Pooky : Infuser les familiers~
+@69 = ~Familier indelebile~
+@70 = ~Changement de sorts pour les ensorceleurs~
+@71 = ~Changer les sorts a tous les niveaux~
+@72 = ~Changer les sorts tous les 3 niveaux~
+//unused
+@79 = ~Selection de sorts par dialogue~
+@80 = ~Ensorceleurs multiclasses~
+@82 = ~Kit de mage : Arcaniste (Ne pas installer si vous prevoyez d'utiliser le lancer de sorts 5E pour tout le monde)~
+@85 = ~Kit d'ensorceleur : ensorceleur a mana~
+@91 = ~Rendre les objets a emplacement de sorts bonus compatibles avec les ensorceleurs multi et les arcanistes~
+@92 = ~Bonus pour la memorisation ET les emplacements de preparation~
+@93 = ~Bonus seulement pour les emplacements de preparation~
+@95 = ~Bonus de lancer pour les scores de caracteristiques (installer APRES tout mod qui modifie les tables de sorts !)~
+
+@100 = ~~
+@101 = ~ABJURATEUR : mage spécialisé dans la magie protectrice et les disciplines métamagiques. Ces mages peuvent ériger de puissantes protections et barrières et ont aussi l'entraînement nécessaire pour les détruire quand elles sont créées par d'autres lanceurs de sorts.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de l'Abjuration comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Abjuration.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Abjuration.
+- Peut lancer spontanément n'importe quel sort de l'école de l'Abjuration en sacrifiant un sort mémorisé.
+- Gagne un Bouclier de sort quand il lance un sort de protection (comme Globe d'invulnérabilité) de l'école de l'Abjuration.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@102 = ~CONJURATEUR : mage spécialisé dans la création de créatures et d'objets qui lui sont utiles en les déplaçant dans l'espace. À terme, ces mages maîtrisent la magie de téléportation et peuvent bannir leurs ennemis et convoquer de l'aide depuis divers plans.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de la Conjuration comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Conjuration.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Conjuration.
+- Peut lancer spontanément n'importe quel sort de l'école de la Conjuration en sacrifiant un sort mémorisé.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@103 = ~DEVIN : mage spécialisé dans la magie de détection et de divination. Ces mages développent une faculté instinctive de percevoir le futur. Même si ces visions sont rarement claires, elles suffisent pour améliorer légèrement les réflexes des devins et leur donner accès à des magies capables d'altérer subtilement les résultats des événements aléatoires.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de la Divination comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Divination.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Divination.
+- Peut lancer spontanément n'importe quel sort de l'école de la Divination en sacrifiant un sort mémorisé.
+- Immunisé contre les attaques sournoises.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@104 = ~ENCHANTEUR : mage spécialisé dans la manipulation de l'esprit des êtres sensibles.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de l’Enchantement comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l’Enchantement.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l’Enchantement.
+- Peut lancer spontanément n'importe quel sort de l'école de l’Enchantement en sacrifiant un sort mémorisé.
+- Immunisé contre le charme et le sommeil.
+- Les membres du groupe bénéficient d'un bonus de 1 point aux jets de sauvegarde contre les sorts.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@105 = ~ILLUSIONNISTE : mage spécialisé dans la création d'illusions pour embrouiller et induire en erreur les autres. Ces mages rusés sont capables de distordre la lumière et de manipuler les sens de bien des manières. Ils peuvent disparaître hors de vue au premier danger et, avec l'expérience, créer des illusions d'un réalisme étonnants.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de l'Illusion comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Illusion.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Illusion.
+- Peut lancer spontanément n'importe quel sort de l'école de l'Illusion en sacrifiant un sort mémorisé.
+- Sous l'effet de Non détection de façon permanente.
+- Peut utiliser la faculté Pas de l'ombre une fois par jour. Des utilisations supplémentaires sont obtenues tous les 5 niveaux.
+
+PAS DE L'OMBRE : permet d'entrer dans le Plan des Ombres et de s'y déplacer pendant 7 secondes, tandis que le temps est figé pour tous les autres. Dans cet état, l'illusionniste ne peut ni attaquer ni lancer de sorts.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@106 = ~INVOCATEUR : mage spécialisé dans la manipulation des énergies brutes et élémentaires. Ces mages utilisent la magie pour manipuler les énergies de base du multivers. Ils sont particulièrement doués pour libérer cette énergie en explosions de feu ou d'éclairs, ou la dévier pour projeter du givre.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de l'Invocation comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Invocation.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Invocation.
+- Peut lancer spontanément n'importe quel sort de l'école de l'Invocation en sacrifiant un sort mémorisé.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@107 = ~NÉCROMANCIEN : mage spécialisé dans la magie liée à la mort, la non-vie et l'énergie provenant du plan matériel négatif. La nécromancie est un art perturbant, méprisé par la plupart des pratiquants civilisés et les académies de magie. Les nécromanciens expérimentent sur les vivants et les morts et créent des abominations mortes-vivantes à cheval entre les deux.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de la Nécromancie comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Nécromancie.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Nécromancie.
+- Peut lancer spontanément n'importe quel sort de l'école de la Nécromancie en sacrifiant un sort mémorisé.
+- Peut émettre une aura qui Intimide les morts-vivants à proximité.
+- Peut utiliser Toucher glacial à volonté.
+- Niveau 3 : peut utiliser Toucher de la goule à volonté.
+- Niveau 5 : peut utiliser Toucher vampirique à volonté.
+
+INTIMIDATION DES MORTS-VIVANTS : Les morts-vivants jusqu'à 5 niveaux de plus que le nécromancien doivent réussir un jet de sauvegarde contre la pétrification à chaque round sous peine d'être ralentis. Ceux de niveau compris entre le niveau du nécromancien et cinq niveaux en dessous qui échouent le jet sont immobilisés. Ceux qui sont inférieurs d'au moins 6 niveaux qui échouent sont contrôlés.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@108 = ~TRANSMUTATEUR : mage spécialisé dans la magie qui altère la réalité physique. Ces mages contrôlent la matière et la transforment de toutes les façons que leur permettent leurs connaissances en magie. Ils peuvent transformer l'air en brume toxique, changer leur propre forme pour prendre celle d'un monstre puissant et même arrêter le temps. Les transmutateurs sont aussi des alchimistes qui créent les diverses potions magiques sur lesquelles les aventuriers se reposent.
+
+Avantages :
+- Un sort supplémentaire par niveau.
+– Apprend tous les sorts de l'école de la Transmutation comme sorts bonus.
+- Bénéficie d'un bonus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Transmutation.
+- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Transmutation.
+- Peut lancer spontanément n'importe quel sort de l'école de la Transmutation en sacrifiant un sort mémorisé.
+- Immunisé contre la pétrification, le polymorphisme et la désintégration.
+
+Inconvénients :
+- Souffre d'un malus de 15 % pour apprendre des parchemins des autres écoles.~
+
+@110 = ~- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Conjuration.~
+@111 = ~– Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Conjuration.
+– niveau 2 : Peut lancer Convocation de Monstres I une fois par jour. Une utilisation supplémentaire est obtenue au niveau 4.
+– niveau 6 : Peut lancer Convocation de Monstres II une fois par jour. Une utilisation supplémentaire est obtenue au niveau 8.
+– niveau 10 : Peut lancer Convocation de Monstres III une fois par jour.~
+@112 = ~– Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de la Conjuration.
+– Peut lancer les sorts de Convocation de Monstres comme s'ils étaient d'un niveau inférieur de 1.~
+
+@113 = ~- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Invocation.~
+@114 = ~- Les cibles souffrent d'un malus de 2 points pour les jets de sauvegarde contre les sorts de l'école de l'Invocation.
+- Inflige +20 % de dégâts avec les sorts qui provoquent des dégâts de froid, de feu, d'électricité ou de magie.~
+
+@125 = ~Intimidation des morts-vivants~
+@126 = ~Annule intimidation des morts-vivants~
+
+//DRAGON DISCIPLES
+@200 = ~~
+@201 = ~disciple du dragon acide~
+@202 = ~Disciple du dragon acide~
+@203 = ~DISCIPLE DU DRAGON ACIDE : Les disciples du dragon sont de puissants ensorceleurs ayant du sang de dragon quelque part dans leur lignée. Leur talent naturel pour la magie fait rejaillir leur héritage draconique et leur permet de lancer des sorts puissants et de manifester des facultés similaires aux dragons. Les disciples du dragon acides héritent soit d'un cruel dragon noir, soit d'un dragon vert traître, soit d'un astucieux dragon de cuivre.
+
+Avantages :
+- Peut soustraire son modificateur de charisme de sa classe d'armure de base.
+- gagne une résistance à l'acide innée de 50 %.
+- Inflige +25 % de dégâts avec les sorts qui provoquent des dégâts d'acide.
+– Dé de vie : d6
+
+Inconvénients :
+- Peut lancer un sort de moins part jour.~
+
+@204 = ~disciple du dragon électrique~
+@205 = ~Disciple du dragon électrique~
+@206 = ~DISCIPLE DU DRAGON ÉLECTRIQUE : Les disciples du dragon sont de puissants ensorceleurs ayant du sang de dragon quelque part dans leur lignée. Leur talent naturel pour la magie fait rejaillir leur héritage draconique et leur permet de lancer des sorts puissants et de manifester des facultés similaires aux dragons. Les disciples du dragon électriques héritent soit d'un dragon bleu manipulateur, soit d'un honorable dragon de bronze.
+
+Avantages :
+- Peut soustraire son modificateur de charisme de sa classe d'armure de base.
+- gagne une résistance à l'électricité innée de 50 %.
+- Inflige +25 % de dégâts avec les sorts qui provoquent des dégâts d'électricité.
+– Dé de vie : d6
+
+Inconvénients :
+- Peut lancer un sort de moins part jour.~
+
+@207 = ~disciple du dragon du froid~
+@208 = ~Disciple du dragon du froid~
+@209 = ~DISCIPLE DU DRAGON DU FROID : Les disciples du dragon sont de puissants ensorceleurs ayant du sang de dragon quelque part dans leur lignée. Leur talent naturel pour la magie fait rejaillir leur héritage draconique et leur permet de lancer des sorts puissants et de manifester des facultés similaires aux dragons. Les disciples du dragon du froid héritent soit d'un robuste dragon blanc, soit d'un dragon d'agent élégant.
+
+Avantages :
+- Peut soustraire son modificateur de charisme de sa classe d'armure de base.
+- gagne une résistance innée au froid de 50 %.
+- Inflige +25 % de dégâts avec les sorts qui provoquent des dégâts de froid.
+– Dé de vie : d6
+
+Inconvénients :
+- Peut lancer un sort de moins part jour.~
+
+@210 = ~disciple du dragon du feu~
+@211 = ~Disciple du dragon du feu~
+@212 = ~DISCIPLE DU DRAGON DU FEU : Les disciples du dragon sont de puissants ensorceleurs ayant du sang de dragon quelque part dans leur lignée. Leur talent naturel pour la magie fait rejaillir leur héritage draconique et leur permet de lancer des sorts puissants et de manifester des facultés similaires aux dragons. Les disciples du dragon du feu héritent soit d'un dragon rouge cupide, soit d'un dragon d'airain curieux, ou encore d'un puissant dragon d'or.
+
+Avantages :
+- Peut soustraire son modificateur de charisme de sa classe d'armure de base.
+- gagne une résistance innée au feu de 50 %.
+- Inflige +25 % de dégâts avec les sorts qui provoquent des dégâts de feu.
+– Dé de vie : d6
+
+Inconvénients :
+- Peut lancer un sort de moins part jour.~
+
+//unused
+@213 = ~Peut soustraire son modificateur de charisme de sa classe d'armure de base.~
+//unused
+@214 =  ~A une classe d'armure de base de 7.~
+
+@300 = ~~
+@301 = ~magus~
+@302 = ~Magus~
+@303 = ~MAGUS : Étudiant à la fois les connaissances profanes et le combat martial, le magus allie les sorts et l'acier avec des résultats dévastateurs. La caractéristique la plus marquante d'un magus est sa capacité à lancer les sorts profanes les plus compliqués en portant les armures les plus encombrantes, qui leur a permis de surprendre bien des ennemis, qui s'attendaient à un combat purement physique. Les magus sont des perfectionnistes et apprécient toute opportunité de perfectionner leurs aptitudes.
+
+Avantages :
+- Peut se spécialiser (2 étoiles) dans toutes les armes de corps à corps.
+- Peut se spécialiser (2 étoiles) dans les styles de combat Arme à deux mains et Arme à une main.
+- Peut lancer des sorts en armure.
+– Dé de vie : d8
+
+Inconvénients :
+- Ne peut pas utiliser de boucliers.
+- Peut lancer un sort de moins chaque jour.
+- Pénalité permanente au Temps d'incantation de 2 points.
+~
+
+@400 = ~~
+//unused
+@401 = ~arcaniste~ 
+@402 = ~Arcaniste~ 
+@403 = ~ARCANISTE : L'arcaniste combine la polyvalence du mage avec la puissance brute de l'ensorceleur. Alors que de nombreux ensorceleurs se révèlent incapables d'apprendre la magie de façon scolaire, les arcanistes peuvent adapter leur propre magie innée par l'étude attentive de tomes de magie profane et la méditation sur la nature de la magie.
+
+Avantages :
+- Peut changer de sorts connus en consommant des parchemins profanes avec la faculté Polyvalence profane.
+
+Inconvénients :
+- Peut lancer un sort de moins chaque jour.
+- Pénalité permanente de 1 point au temps d'incantation.~
+
+@404 = ~Polyvalence profane~
+@405 = ~Polyvalence profane
+
+Cette faculté vous permet de changer vos sorts connus. Pour apprendre un nouveau sort, vous devrez sacrifier un sort déjà connu du même niveau et fournir un parchemin du nouveau sort.~
+
+
+@600 = ~~
+@601 = ~âme favorite~
+@602 = ~Âme favorite~
+@603 = ~ÂME FAVORITE : les âmes favorites voient leurs pouvoirs magiques comme la bénédiction d'une divinité. Cette bénédiction leur accorde de puissantes protections magiques et des sorts normalement hors de portée des ensorceleurs.
+
+Avantages :
+- Apprend tous les sorts d'une sphère divine comme sorts bonus.
+- Sous l'effet du sort Protection contre le mal de façon permanente.
+- Bonus de 2 points à tous les jets de sauvegarde.
+
+Inconvénients :
+- Peut lancer un sort de moins chaque jour.
+~
+
+@604 = ~Sélection de Sphère~
+@605 = ~Sélection de Sphère
+
+Permet à l'âme favorite de choisir une sphère de magie divine, ce qui leur donne accès à un jeu de sorts divins.~
+@606 = ~Choisir une des sphères suivantes.~
+@607 = ~Combat~
+@608 = ~Mort~
+@609 = ~Guérison~
+@610 = ~Nature~
+@611 = ~Protection~
+@612 = ~Sphère du Combat
+
+  1 : Pierre magique
+  1 : Apaisement
+  2 : Puiser dans la puissance divine
+  2 : Lame enflammée
+  3 : Force d'un seul
+  4 : Manteau de terreur
+  5 : Force de Champion
+  6 : Barrière de lames
+  7 : Portail
+~ 
+@613 = ~Choisir cette sphère.~
+@614 = ~Examiner d'autres sphères.~
+@615 = ~Quitter~
+@616 = ~Sphère de la Mort
+
+  1 : Injonction
+  1 : Imprécation
+  2 : Immobilisation de Personne
+  2 : Marteau spirituel
+  3 : Animation des morts-vivants
+  4 : Protection contre la mort
+  5 : Mise à mort
+  6 : Rayon divin
+  7 : Parole infernale
+~
+@617 = ~Sphère de la Guérison
+
+  1 : Bénédiction
+  1 : Soin des blessures légères
+  2 : Aide
+  2 : Ralentissement du poison
+  3 : Soin des blessures moyennes
+  4 : Restauration mineure
+  5 : Guérison de masse
+  6 : Guérison
+  7 : Résurrection
+~
+@618 = ~Sphère de la Nature
+
+  1 : Enchevêtrement
+  1 : Gourdin magique
+  2 : Peau d'écorce
+  2 : Baies magiques
+  3 : Convocation d'insectes
+  4 : Appel des créatures des bois
+  5 : Poussière de fée
+  6 : Semences de feu
+  7 : Beauté de la Nature
+~
+@619 = ~Sphère de la  Protection
+
+  1 : Armure de la foi
+  1 : Sanctuaire
+  2 : Cantique
+  2 : Silence sur 5 mètres
+  3 : Glyphe de garde
+  4 : Harmonie défensive
+  5 : Résistance à la magie
+  6 : Miroir physique
+  7 : Bouclier des archontes
+~
+
+@700 = ~~
+@701 = ~disciple sylvain~
+@702 = ~Disciple sylvain~
+@703 = ~DISCIPLE SYLVAIN : Le naturel capricieux des fées coule dans les veines des ensorceleurs sylvains à cause d'un métissage depuis longtemps oublié. Ces ensorceleurs sont plus émotifs que les autres, sujets à des poussées de joie ou de rage.
+
+Avantages :
+- Sous l'effet permanent du Sort Non-détection.
+- Bonus de 4 point aux jets de sauvegarde contre les sorts.
+- Immunisé contre les charmes.
+- Les créatures qui attaquent le disciple sylvain en mêlée doivent réussir un jet de sauvegarde contre les sorts sous peine de subir une pénalité de 2 points à l'attaque pendant 1 round.
+
+Inconvénients :
+- Peut lancer un sort de moins chaque jour.
+~
+
+@800 = ~~
+@801 = ~disciple revenant ~
+@802 = ~Disciple revenant ~
+@803 = ~DISCIPLE REVENANT : la souillure de la tombe se transmet dans les familles des disciples revenants. Peut-être un de leurs ancêtres est devenu une puissante liche ou un vampire, ou peut-être même sont ils morts-nés avant de revenir brutalement à la vie. Quoi qu’il en soit, les forces de la mort se meuvent avec eux et ternissent toutes leurs actions.
+
+Avantages :
+- Bonus de 4 points aux jets de sauvegarde contre la mort.
+- Immunisé contre la magie de sommeil et de mort.
+– Dés de vie : d6
+
+Inconvénients :
+- Peut lancer un sort de moins chaque jour.
+~
+
+@900 = ~~
+@901 = ~disciple amorphe~
+@902 = ~Disciple amorphe~
+@903 = ~DISCIPLE AMORPHE : L'ichor infâme des vases coulent dans leurs veines et leur accorde un contrôle magique des produits toxiques et des vases, mais aussi un don pour changer de forme à sa guise.
+
+Avantages :
+- Bonus de 4 points aux jets de sauvegarde contre la métamorphose.
+- Immunisé contre la maladie et le poison.
+- Protégé contre les vases.
+
+Inconvénients :
+- Peut lancer un sort de moins chaque jour.
+~
+  // in description of wizard/sorc. to be replaced by @1002
+@1001 = ~Peut lancer des sorts profanes.~
+@1002 = ~Peut lancer des sorts profanes.
+– Peut convoquer un familier.~
+//
+@1006  = ~Avantages :~
+@1007  = ~Capacités :~
+@1008  = ~Inconvénients :~
+@1009  = ~Restrictions :~
+//
+@1100  = ~Mémoriser des sorts~
+// @1101 to be replaced with @1102 when bard armored casting is chosen
+@1101 = ~(les sorts ne peuvent être lancés en armure)~
+@1102 = ~(les sorts ne peuvent être lancés en armure plus lourde que les besantines)~
+@1105 = ~Initialisation de l'apprentissage des sorts à la manière des ensorceleurs~ // using same translation as semi-spont @300
+// 1401 to be replaced by @1402 - mage: add crafting in description
+@1401 = ~Peut lancer des sorts profanes.~
+@1402 = ~Peut lancer des sorts profanes.
+– Peut utiliser Écriture de parchemins.
+- niveau 5 : peut utiliser Création de potions.
+- niveau 10 : peut utiliser Création de baguettes.
+- niveau 15 : peut utiliser Rechargement de baguettes.~
+// 1403 to be replaced by @1404 -sorcerer: add crafting in description
+@1403 = ~Peut lancer des sorts profanes.~
+@1404 = ~Peut lancer des sorts profanes.
+- niveau 5 : peut utiliser Création de potions.
+- niveau 10 : peut utiliser Création de baguettes.
+- niveau 15 : peut utiliser Rechargement de baguettes.~
+// 1501 to be replaced by @1502 - mage or sorcerer: add cantrip in description
+@1501 = ~Peut lancer des sorts profanes.~
+@1502 = ~Peut lancer des sorts profanes.
+– Peut choisir un tour de magie.~
+// 1503 to be replaced by one of @1504-@1511 - specialist: add cantrip in description
+@1503 = ~Un sort supplémentaire par niveau.~
+@1504 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Coquille protectrice.~
+@1505 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Convocation de lapin.~
+@1506 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Anticipation.~
+@1507 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Somnolence.~
+@1508 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Égarement.~
+@1509 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Carreau magique.~
+@1510 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Raidissement des os.~
+@1511 = ~Un sort supplémentaire par niveau.
+- Peut utiliser le tour de magie Poigne terreuse.~
+// 1512 to be replaced by one of @1513-@1521 - sorcerers kits: add cantrip in description
+@1512 = ~Avantages :~
+@1513 = ~Avantages :
+- Peut utiliser le tour de magie Carreau de feu.~
+@1514 = ~Avantages :
+- Peut utiliser le tour de magie Coquille protectrice.~
+@1515 = ~Avantages :
+- Peut utiliser le tour de magie Carreau acide.~
+@1516 = ~Avantages :
+- Peut utiliser le tour de magie Carreau glacé.~
+@1517 = ~Avantages :
+- Peut utiliser le tour de magie Carreau électrique.~
+@1518 = ~Avantages :
+- Peut utiliser le tour de magie Anticipation.~
+@1519 = ~Avantages :
+- Peut utiliser le tour de magie Somnolence.~
+@1520 = ~Avantages :
+- Peut utiliser le tour de magie Raidissement des os.~
+@1521 = ~Avantages :
+- Peut utiliser le tour de magie Poigne terreuse.~
+
+@1701 = ~Connaissance de sort~
+@1702 = ~Connaissance de sort
+
+Permet de choisir vos sorts connus pour chaque niveau de sorts.~
+@1703 = ~Apprendre ce sort.~
+@1704 = ~Examiner d'autres sorts du même niveau.~
+@1705 = ~Choisir un autre niveau de sorts.~
+@1706 = ~Terminer.~
+@1707 = ~Retourner à la sélection de niveau.~
+@1708 = ~Vous pouvez apprendre plus de sorts des niveaux suivants.~
+@1711 = ~Premier~
+@1712 = ~Second~
+@1713 = ~Troisième~
+@1714 = ~Quatrième~
+@1715 = ~Cinquième~
+@1716 = ~Sixième~
+@1717 = ~Septième~
+@1718 = ~Huitième~
+@1719 = ~Neuvième~
+@1721 = ~Vous pouvez choisir de nouveaux sorts de niveau 1 dans la liste suivante.~
+@1722 = ~Vous pouvez choisir de nouveaux sorts de niveau 2 dans la liste suivante.~
+@1723 = ~Vous pouvez choisir de nouveaux sorts de niveau 3 dans la liste suivante.~
+@1724 = ~Vous pouvez choisir de nouveaux sorts de niveau 4 dans la liste suivante.~
+@1725 = ~Vous pouvez choisir de nouveaux sorts de niveau 5 dans la liste suivante.~
+@1726 = ~Vous pouvez choisir de nouveaux sorts de niveau 6 dans la liste suivante.~
+@1727 = ~Vous pouvez choisir de nouveaux sorts de niveau 7 dans la liste suivante.~
+@1728 = ~Vous pouvez choisir de nouveaux sorts de niveau 8 dans la liste suivante.~
+@1729 = ~Vous pouvez choisir de nouveaux sorts de niveau 9 dans la liste suivante.~
+
+//Subtledoctor TRA strings
+//
+// ... multiclass sorcerers 
+//
+@17011  = ~Sorts de niveau 1~
+@17012  = ~Sorts de niveau 2~
+@17013  = ~Sorts de niveau 3~
+@17014  = ~Sorts de niveau 4~
+@17015  = ~Sorts de niveau 5~
+@17016  = ~Sorts de niveau 6~
+@17017  = ~Sorts de niveau 7~
+@17018  = ~Sorts de niveau 8~
+@17019  = ~Sorts de niveau 9~
+@17021  = ~Connaissance de sorts profanes~
+@17022  = ~Connaissance de sorts profanes
+
+Permet de choisir vos sorts de mage pour chaque niveau de sorts.~
+@17023 = ~Apprendre ce sort.~
+@17024 = ~Examiner d'autres sorts du même niveau.~
+@17025 = ~Choisir un autre niveau de sorts.~
+@17026 = ~Terminer.~
+@17027 = ~Retourner à la sélection de niveau.~
+@17028 = ~Vous pouvez apprendre plus de sorts des niveaux suivants.~
+@17031 = ~Sorts du premier niveau~
+@17032 = ~Sorts du second niveau~
+@17033 = ~Sorts du troisième niveau~
+@17034 = ~Sorts du quatrième niveau~
+@17035 = ~Sorts du cinquième niveau~
+@17036 = ~Sorts du sixième niveau~
+@17037 = ~Sorts du septième niveau~
+@17038 = ~Sorts du huitième niveau~
+@17039 = ~Sorts du neuvième niveau~
+@17041 = ~Vous pouvez choisir de nouveaux sorts de niveau 1 dans la liste suivante.~
+@17042 = ~Vous pouvez choisir de nouveaux sorts de niveau 2 dans la liste suivante.~
+@17043 = ~Vous pouvez choisir de nouveaux sorts de niveau 3 dans la liste suivante.~
+@17044 = ~Vous pouvez choisir de nouveaux sorts de niveau 4 dans la liste suivante.~
+@17045 = ~Vous pouvez choisir de nouveaux sorts de niveau 5 dans la liste suivante.~
+@17046 = ~Vous pouvez choisir de nouveaux sorts de niveau 6 dans la liste suivante.~
+@17047 = ~Vous pouvez choisir de nouveaux sorts de niveau 7 dans la liste suivante.~
+@17048 = ~Vous pouvez choisir de nouveaux sorts de niveau 8 dans la liste suivante.~
+@17049 = ~Vous pouvez choisir de nouveaux sorts de niveau 9 dans la liste suivante.~
+
+@17050 = ~Initialisation de l'apprentissage des sorts à la manière des ensorceleurs~//mana sorc.
+@17051 = ~guerrier/ensorceleur~
+@17052 = ~Guerrier/Ensorceleur~
+@17053 = ~GUERRIER/ENSORCELEUR : Les ensorceleurs sont des pratiquants de la magie nés avec le don de lancer des sorts. On pense que le sang d'une puissante créature coule dans leurs veines. Ils sont peut-être des rejetons des dieux eux-mêmes, voire des dragons ayant pris forme humaine. Néanmoins, la magie des ensorceleurs est plus intuitive que logique. Ils connaissent moins de sorts que les mages et les apprennent plus lentement, mais ils peuvent en lancer plus souvent et n'ont pas besoin de sélectionner et de préparer des sorts à l'avance.
+
+Avantages :
+- Peut lancer des sorts profanes.
+- Les ensorceleurs ne retranscrivent pas leurs sorts dans un livre de sorts comme le font les mages. À la place, ils apprennent un petit nombre de sorts à chaque niveau qu'ils peuvent lancer sans avoir besoin de les mémoriser.
+
+Inconvénients :
+- Ne peut apprendre de sorts depuis un parchemin.
+- Ne peut lancer le sort Identification.
+- Ne peut utiliser les séquenceurs de sorts ou les sorts de contingence.
+~
+@17061 = ~ensorceleur/clerc~
+@17062 = ~Ensorceleur/Clerc~
+@17063 = ~ENSORCELEUR/CLERC : Les ensorceleurs sont des pratiquants de la magie nés avec le don de lancer des sorts. On pense que le sang d'une puissante créature coule dans leurs veines. Ils sont peut-être des rejetons des dieux eux-mêmes, voire des dragons ayant pris forme humaine. Néanmoins, la magie des ensorceleurs est plus intuitive que logique. Ils connaissent moins de sorts que les mages et les apprennent plus lentement, mais ils peuvent en lancer plus souvent et n'ont pas besoin de sélectionner et de préparer des sorts à l'avance.
+
+Avantages :
+- Peut lancer des sorts profanes.
+- Les ensorceleurs ne retranscrivent pas leurs sorts dans un livre de sorts comme le font les mages. À la place, ils apprennent un petit nombre de sorts à chaque niveau qu'ils peuvent lancer sans avoir besoin de les mémoriser.
+
+Inconvénients :
+- Ne peut apprendre de sorts depuis un parchemin.
+- Ne peut lancer le sort Identification.
+- Ne peut utiliser les séquenceurs de sorts ou les sorts de contingence.
+~
+@17071 = ~ensorceleur/voleur~
+@17072 = ~Ensorceleur/voleur~
+@17073 = ~ENSORCELEUR/VOLEUR : Les ensorceleurs sont des pratiquants de la magie nés avec le don de lancer des sorts. On pense que le sang d'une puissante créature coule dans leurs veines. Ils sont peut-être des rejetons des dieux eux-mêmes, voire des dragons ayant pris forme humaine. Néanmoins, la magie des ensorceleurs est plus intuitive que logique. Ils connaissent moins de sorts que les mages et les apprennent plus lentement, mais ils peuvent en lancer plus souvent et n'ont pas besoin de sélectionner et de préparer des sorts à l'avance.
+
+Avantages :
+- Peut lancer des sorts profanes.
+- Les ensorceleurs ne retranscrivent pas leurs sorts dans un livre de sorts comme le font les mages. À la place, ils apprennent un petit nombre de sorts à chaque niveau qu'ils peuvent lancer sans avoir besoin de les mémoriser.
+
+Inconvénients :
+- Ne peut apprendre de sorts depuis un parchemin.
+- Ne peut lancer le sort Identification.
+- Ne peut utiliser les séquenceurs de sorts ou les sorts de contingence.
+~
+@17081 = ~ensorceleur à mana~
+@17082 = ~Ensorceleur à mana~
+@17083 = ~ENSORCELEUR À MANA : Les ensorceleurs sont des pratiquants de la magie nés avec le don de lancer des sorts. On pense que le sang d'une puissante créature coule dans leurs veines. Ils sont peut-être des rejetons des dieux eux-mêmes, voire des dragons ayant pris forme humaine. Néanmoins, la magie des ensorceleurs est plus intuitive que logique. Ils connaissent moins de sorts que les mages et les apprennent plus lentement, mais ils peuvent en lancer plus souvent et n'ont pas besoin de sélectionner et de préparer des sorts à l'avance.
+
+Avantages :
+- Peut lancer des sorts profanes.
+- Les ensorceleurs ne retranscrivent pas leurs sorts dans un livre de sorts comme le font les mages. À la place, ils apprennent un petit nombre de sorts à chaque niveau qu'ils peuvent lancer sans avoir besoin de les mémoriser.
+- Les ensorceleurs à mana n'utilisent pas d'"emplacements de sorts" de niveaux différents. Au lieu de cela, ils disposent d'un nombre de points de mana qu'ils utilisent en lançant des sorts. Chaque sort lancé réduit le nombre de points de mana d'un nombre égal au niveau du sort. les points de mana sont récupérés quand l'ensorceleur se repose.
+
+Inconvénients :
+- Ne peut apprendre de sorts depuis un parchemin.
+~
+@17085 = ~Changer la méthode de lancer de sorts~
+@17087 = ~Méditation reconstituante~
+@17088 = ~Méditation reconstituante : cette faculté permet à un ensorceleur de se reposer et de méditer entre des combats et de récupérer une partie de ses points de mana.~
+@17091 = ~Comment voulez-vous lancer vos sorts ?~
+@17092 = ~Avec des emplacements de sorts comme un ensorceleur normal.~
+@17093 = ~Avec des points de mana.~
+@17094 = ~Pas de changement ; vous aurez un certain nombre d'emplacement de sorts pour chaque niveau de sort.~
+@17095 = ~Choisir de ne pas changer.~
+@17096 = ~Faire un autre choix.~
+@17097 = ~Lancer de sorts par points de mana ; vous disposerez d'un nombre de points de mana que vous dépenserez pour lancer des sorts de tout niveau. Vous apprendrez des sorts en utilisant un objet plutôt que par l'écran de montée de niveau.~
+@17098 = ~Choisir de lancer les sorts avec des points de mana.~
+@6005   = ~Lancer de sort spontané~
+@6006   = ~Annuler la conversion spontanée de sort~
+
+// abjurer - no SR
+@6201   = ~Globe d'invulnérabilité mineur+~
+@6202   = ~Renvoi des sorts mineur+~
+@6203   = ~Déviation des sorts+~
+@6204   = ~Globe d'invulnérabilité+~
+@6205   = ~Renvoi des sorts+~
+@6206   = ~Piège à Sorts+~
+//abjurer - SR
+@6211   = ~Globe d'invulnérabilité mineur+~
+@6212   = ~Déviation des sorts+~
+@6213   = ~Déviation des sorts+~
+@6214   = ~Globe d'invulnérabilité+~
+@6215   = ~Déviation de Sorts Majeure+~
+@6216   = ~Piège à Sorts+~
+
+@6251   = ~Toucher glacial~
+@6252   = ~Toucher glacial
+
+Grâce à ce sort, une lueur bleue entoure la main du nécromancien. Cette énergie attaque la force vitale de toute créature vivante sur laquelle le magicien réussit une attaque de corps-à-corps.
+
+La créature touchée subit 1d4+1 points de dégâts de froid et doit réussir un jet de sauvegarde contre la mort sous peine d'être ralentie et perdre 3 points de force pendant 3 rounds.
+
+Les créatures mortes-vivantes touchées par cette énergie sont immobilisées pendant deux rounds. Elles n'ont pas droit à un jet de sauvegarde pour éviter cet effet.~
+@6253   = ~Toucher de la goule~
+@6254   = ~Toucher de la goule
+
+Lorsque ce sort est lancé, une lueur rougeâtre entoure la main du jeteur de sorts. Lorsque le nécromancien réussit une attaque de mêlée contre une créature, cette dernière subit 1d4+1 points de dégâts magiques. Si la victime échoue à un jet de sauvegarde contre la mort, le sort continue à infliger 1d4 points de dégâts au deuxième round puis 1d3 point s de dégâts au troisième round. De plus la victime est paralysée pendant 1 round et infectée par une maladie qui diminue sa force, sa dextérité et sa constitution de deux points chacune tous les 5 rounds.~
+@6255   = ~Toucher vampirique~
+@6256   = ~Toucher vampirique
+
+Lorsque ce sort est lancé, une lueur bleu pâle entoure la main du nécromancien. Lorsque le nécromancien réussit une attaque de mêlée contre une créature, cette dernière subit 1d6+1 points de dégâts, tandis que le nécromancien gagne 1d6+1 points de vie (tous les points de vie au-dessus du total maximal de points de vie du lanceur est considéré comme des points de vie temporaires, qui restent 4 tours). Si la victime échoue à un jet de sauvegarde contre la mort avec une pénalité de 2 points, elle perd 1d6 points de vie supplémentaires et subit une perte de 3 points de constitution pendant 1 tour.
+
+Les créatures mortes-vivantes touchées pendant que cette faculté est active sont placées sous le contrôle du nécromancien.~
+@6257   = ~Désactiver Toucher glacial~
+@6258   = ~Désactiver Toucher de la goule~
+@6259   = ~Désactiver Toucher vampirique~
+
+
+//
+// spell-switching TRA strings
+//
+@8301  = ~Changer un sort connu~
+@8302  = ~Ne changer aucun sort~
+@8303  = ~Changer ce sort~
+@8304  = ~Changer un autre sort~
+//
+// Arcanist-related TRA strings
+//
+@21901  = ~arcaniste~
+@21902  = ~Arcaniste~
+@21903  = ~ARCANISTE : Certains lanceurs de sorts recherchent les secrets de la magie par l'étude acharnée ; d'autres naissent avec la magie dans le sang. Les arcanistes essaient de fusionner la science académique des mages avec la puissance naturelle des lanceurs innés. Un arcaniste doit préparer ses sorts en avance mais, à la différence des mages, ses sorts ne disparaissent pas quand ils sont lancés. Il peut lancer n'importe quel sort qu'il a préparé et consomme un emplacement de lancer du niveau correspondant.
+
+Avantages :
+- Peut apprendre les sorts profanes à l'aide de parchemins, comme le font les mages.
+- Après avoir préparé ses sorts et s'être reposé, peut lancer ses sorts spontanément, comme les font les ensorceleurs.
+
+Inconvénients :
+- Ne peut se spécialiser dans une école de magie, comme les mages traditionnels.
+- Les objets qui augmentent le nombre d'emplacements de sorts, comme l'anneau des arcanes, ne peut augmenter le nombre d'emplacements de lancer d'un arcaniste que de 1 pour chaque niveau de sorts.
+~
+@21981 = ~Initialisation du lancer de style arcaniste~
+@21982 = ~Changer les sorts mémorisés~
+@21983 = ~Préparation de sorts
+
+Cette compétence permet à l'arcaniste de préparer une nouvelle collection de sorts pour le jour à venir. Quand cette compétence est utilisée, les emplacements de sorts deviennent accessibles dans le livre de sorts de l'arcaniste et le lancer de sorts est désactivé. Une fois les emplacements de sorts remplis, l'arcaniste doit se reposer pendant 8 heures. Quand il se réveillera, le lancer de sorts sera réactivé et l'arcaniste ne pourra plus modifier le contenu de ses emplacements de sorts jusqu'à ce que cette compétence soit utilisée à nouveau.
+~
+@21984 = ~Les sorts mémorisés peuvent maintenant être changés. Le lancer de sorts est désactivé jusqu'au prochain repos complet.~
+//inserted in class description
+@21985 = ~Restrictions :
+- Ne peut utiliser les séquenceurs de sorts ou les sorts de contingence.~
+@21986 = ~Restrictions :
+- Ne peut lancer le sort Identification.~
+@21989 = ~Emplacement de sort de niveau 8 additionnel~
+@21990 = ~Emplacement de sort de niveau 9 additionnel~
+@21991 = ~Emplacement de sort de niveau 1 additionnel~
+@21992 = ~Emplacement de sort de niveau 2 additionnel~
+@21993 = ~Emplacement de sort de niveau 3 additionnel~
+@21994 = ~Emplacement de sort de niveau 4 additionnel~
+@21995 = ~Emplacement de sort de niveau 5 additionnel~
+@21996 = ~Emplacement de sort de niveau 6 additionnel~
+@21997 = ~Emplacement de sort de niveau 7 additionnel~

--- a/TomeAndBlood/lang/french/spells.tra
+++ b/TomeAndBlood/lang/french/spells.tra
@@ -1,0 +1,479 @@
+
+@6041   = ~Séquenceur mineur~
+@6042   = ~Séquenceur mineur
+(Invocation)
+
+Niveau : 4
+Portée : 0
+Durée : permanente
+Temps d'incantation : 9
+Zone d'effet : spécial
+Jet de sauvegarde : aucun
+
+Ce sort permet à un magicien de stocker des sorts et d'y accéder à partir d'un bouton de capacité spéciale. Deux sorts (de niveau 2 ou inférieur) peuvent ainsi être stockés et lancés simultanément. Le séquenceur ne peut pas être donné à un autre joueur. Un magicien ne peut posséder qu'un seul séquenceur à la fois. Une fois le séquenceur utilisé, le lanceur obtiendra une capacité innée pour en créer un nouveau. (Note : quand ce sort est lancé, il est retiré du livre de sorts et peut dès lors être utilisé depuis le bouton, des capacités spéciales).~
+@6043   = ~Séquenceur de sorts~
+@6044   = ~Séquenceur de sorts
+
+Niveau : 7
+Portée : 0
+Durée : Permanente
+Temps d'incantation : 9
+Zone d'effet : spéciale
+Jet de sauvegarde : aucun
+
+Ce sort permet à un magicien de stocker des sorts et d'y accéder à partir d'un bouton de capacité spéciale. Trois sorts (de niveau 4 ou inférieur) peuvent ainsi être stockés et lancés simultanément. Le séquenceur ne peut pas être donné à un autre joueur. Un magicien ne peut posséder qu'un seul séquenceur à la fois. Une fois le séquenceur utilisé, le lanceur obtiendra une capacité innée pour en créer un nouveau. (Note : quand ce sort est lancé, il est retiré du livre de sorts et peut dès lors être utilisé depuis le bouton, des capacités spéciales).~
+@6045   = ~Déclencheur de sorts~
+@6046   = ~Déclencheur de sorts
+
+Niveau : 8
+Portée : 0
+Durée : permanente
+Temps d'incantation : 9
+Zone d'effet : Lanceur
+Jet de Sauvegarde : aucun
+
+Ce sort permet de stocker jusqu'à trois sorts de niveau 6 ou moins et de pouvoir y accéder par le bouton de capacité spéciale, ce qui permet de les lancer simultanément. Un seul Déclencheur peut être utilisé à la fois, et il ne peut être cédé à un autre personnage. Une fois le déclencheur utilisé, le lanceur obtiendra une capacité innée pour en créer un nouveau. (Note : quand ce sort est lancé, il est retiré du livre de sorts et peut dès lors être utilisé depuis le bouton, des capacités spéciales).~
+@6049   = ~Pas de l'ombre~
+@6050   = ~Pas de l'ombre
+
+Le personnage entre dans le Plan des ombres et s'y déplace pendant 7 secondes, tandis que le temps est figé pour tous les autres. Le lanceur ne peut ni attaquer ni lancer de sorts tant qu'il est dans le Plan des ombres.~
+
+//no SR - school => alteration
+@6111  = ~Glisse
+(Transmutation)
+
+Niveau : 1
+Portée : 9 m
+Durée : 3 rounds + 1 round par niveau
+Temps d'incantation : 1
+Zone d'effet : rayon de 4,5 m
+Jet de sauvegarde : spécial
+
+Le sort de glisse permet de recouvrir une surface matérielle d'une substance huileuse et glissante. Toute créature s'aventurant ou prise au piège dans la zone d'effet au moment où le sort est lancé doit réussir un jet de sauvegarde contre les sorts à +2, sans quoi elle glisse et dérape, étant incapable de bouger. Toute créature réussissant un jet de sauvegarde peut se mouvoir, quoique lentement, jusqu'à la fin du round (mais devra refaire un jet de sauvegarde contre les sorts au cours du round suivant). Les créatures restant dans la zone peuvent lancer un jet de sauvegarde à chaque round jusqu'à ce qu'elles s'échappent de la zone.~
+
+//no SR - conjuration->alteration
+@6116  = ~Flèche enflammée
+(Transmutation)
+
+Niveau : 3
+Portée : 18 m
+Durée : 1 round
+Temps d'incantation : 3
+Zone d'effet : 1 créature
+Jet de sauvegarde : demi-dégâts
+
+Ce sort permet au magicien de lancer des carreaux enflammés sur tout ennemi situé à portée de tir. Chaque carreau inflige 1d6 points de dégâts perforants, plus 4d6 points de dégâts de feu. La cible ne subit que la moitié des dégâts du feu si elle réussit un jet de sauvegarde contre les sorts. Le lanceur de sorts peut créer un carreau pour chaque tranche de cinq niveaux d'expérience (2 carreaux au 10e niveau, 3 au 15e niveau, etc.) Tous les carreaux sont tirés sur la cible du sort.~
+//no SR - already enchanntment?
+@6117  = ~Grande malédiction
+(Enchantement/Charme)
+
+Niveau : 4
+Portée : 15 m
+Durée : 2 rounds par niveau 
+Temps d'incantation : 4 
+Zone d'effet : rayon de 4,5 m 
+Jet de sauvegarde : aucun
+
+Ce sort permet d'influencer de façon défavorable tous les jets de sauvegarde ennemis. Ses effets s'appliquent à toute créature hostile située dans la zone d'effet. Les adversaires sous l'influence de ce sort effectuent tous leurs jets de sauvegarde avec un malus de -4.
+~
+//no SR - invisible stalker -> shadow stalker and conjuration-> illusion
+@6118  = ~Chasseur de l'ombre
+(Illusion/Phantasme)
+
+Niveau : 6
+Portée : 36,5 m
+Durée : 9 heures
+Temps d'incantation : 9
+Zone d'effet : spéciale
+Jet de sauvegarde : aucun
+
+Ce sort crée un double du lanceur fait d'ombre pure et lui accorde un certain niveau d'autonomie. Floue et difforme, cette entité combattra pour le lanceur pendant 9 heures (ou jusqu'à sa destruction violente).~
+//no SR version - +4 version - school Invocation => Enchantment
+@6119  = ~Épée de Mordenkainen
+(Enchantement/Charme)
+
+Niveau : 7
+Portée : 0
+Durée : 1 round par niveau
+Temps d'incantation : 7
+Zone d'effet : spéciale
+Jet de sauvegarde : aucun
+
+Ce sort fait apparaître une sorte de champ de force en forme d'épée dans les mains du magicien qui le lance. Lorsqu'il manipule cette arme, le lanceur est considéré comme un guerrier de niveau moitié moindre que le sien. Cette épée est assimilée à une arme +4 et inflige 5d4 points de dégâts à chaque attaque réussie. L'épée flottant dans les airs sous le contrôle du magicien, ce dernier peut continuer à accomplir d'autres actions pendant la durée du sort.~
+
+//SR and no SR
+@6124   = ~Désintégration~
+//no SR alteration-> necromancy
+@6125   = ~Désintégration
+(Nécromancie)
+
+Niveau : 6
+Portée : Champ visuel du lanceur
+Durée : Instantanée
+Temps d'incantation : 6
+Zone d'effet : 1 créature
+Jet de Sauvegarde : Annule
+
+Un rayon vert est dirigé vers la cible. Au contact, celle-ci doit réussir un Jet de Sauvegarde contre les sorts ou être transformée en poussière. Cette transformation est immédiate et irréversible. Ce sort a également une grande chance de détruire tout ou partie de l'équipement de la cible.~
+
+// SR - conjuration->alteration
+@6132  = ~Flèche Enflammée
+
+Niveau : 3
+École : Transmutation
+Portée : longue
+Durée : instantanée
+Temps d'incantation : 3
+Zone d'effet : spéciale
+Jet de sauvegarde contre le souffle : 1/2 dégâts
+
+Ce sort permet au magicien de lancer des flèches enflammées sur ses ennemis. Le jeteur du sort peut créer une flèche pour chaque tranche de 2 niveaux d'expérience (jusqu'à un maximum de 5 flèches au niveau 10), chaque flèche infligeant 1d6 de dégâts de projectiles plus 2d6 points de dégâts de feu. Un jet de sauvegarde contre le souffle à -2 permet de diviser les dégâts par 2. Une fois l'incantation achevée, la première flèche est tirée sur la créature choisie par le magicien, tandis que les flèches supplémentaires ciblent aléatoirement les ennemis à portée de tir.~
+// SR enchantment -> enchantment
+@6133  = ~Grande Malédiction
+
+Niveau : 4
+Ecole : Enchantement
+Portée : longue
+Durée : 2 rounds / niveau
+Temps d'incantation : 4
+Zone d'effet : rayon de 9 m
+Jet de sauvegarde : aucun
+
+Ce sort permet au lanceur du sort d'affecter négativement les jets de sauvegarde de ses ennemis. L'effet est appliqué à toute créature hostile dans la zone d'effet. Les adversaires sous l'influence de ce sort souffrent d'une pénalité de -2 à tous leurs jets de sauvegarde. Les effets de ce sort ne sont pas cumulatifs.
+~
+// SR conjuration->illusion
+@6135  = ~Chasseur invisible
+
+Niveau : 6
+École : Illusion
+Portée : 36,5 m
+Durée : 9 heures
+Temps d'incantation : 9
+Zone d'effet : spéciale
+Jet de sauvegarde : aucun
+
+Ce sort crée un assassin imaginaire presque invisible avec une vision normale. Cette entité poursuit ses cibles sans relâche et les attaque avec des lames indistinctes. Elle restera relativement stable et servira le lanceur pendant 9 heures (ou jusqu'à sa destruction violente)
+~
+// SR alteration->necromancy
+@6136   = ~Désintégration
+
+Niveau : 6
+Ecole : Nécromancie
+Portée : longue
+Durée : instantanée
+Temps d'incantation : 6
+Zone d'effet : 1 créature
+Jet de sauvegarde contre les souffles : partiel
+
+Ce sort produit un rayon vert qui jaillit des doigts du magicien et touche infailliblement sa cible. Au contact, celle-ci doit réussir un jet de sauvegarde contre les souffles à -2 ou subir 2d6 points de dégâts magiques par niveau du lanceur (jusqu'à un maximum de 40d6). Une créature qui réussit son jet de sauvegarde n'est que partiellement touchée, ne subissant que 5d6 points de dégâts. Le rayon affecte même les objets entièrement faits de force, telle que l'épée de Mordenkainen, qui est automatiquement détruite si elle est touchée. Ce sort n'a pas d'effet sur les vêtements ou équipements de la cible.~
+//SR version - school Invocation => Enchantment
+@6137  = ~Épée de Mordenkainen
+
+Niveau : 7
+École : Enchantement
+Portée : jeteur du sort
+Durée : 1 round / niveau
+Temps d'incantation : 7
+Zone d'effet : spéciale
+Jet de sauvegarde : aucun
+
+Ce sort fait apparaître une sorte de champ de force chatoyant en forme d'épée. L'épée flotte dans les airs sous le contrôle total du magicien, jusqu'à expiration du sort ou jusqu'à dissipation. L'épée est considérée comme une arme +4 et attaque par elle-même une fois par round, infligeant 5d4 points de dégâts. Elle possède 100 % de résistance à presque toute forme de dégâts (acide, froid, feu, électricité, poison, etc.), et 95 % de résistance aux dégâts physiques, mais elle est vulnérable aux dégâts purement magiques. L'épée est immunisée contre les sorts affectant l'esprit, possède 36 points de vie, une CA de 5, et un TAC0 de 2. Note : ce sort n'empêche pas le magicien d'accomplir d'autres actions pendant la durée du sort.~
+
+//
+@6271   = ~Clone illusoire~
+@6272   = ~Clone illusoire
+
+Niveau : 6
+École : Illusion
+Portée : 0
+Durée : 1 round par niveau
+Temps d'incantation : 5
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce sort crée une copie grossière du lanceur, reconnaissable mais imparfaite. Le clone d'ombre a 40 % des points de vie du lanceur et une pénalité de 7 points aux jets d'attaque et au niveau effectif de lanceur. Le clone ne peut utiliser l'objets consommables comme les potions ou les parchemins (qui ne sont pas réellement dupliqués) et ne peut pas lancer de sorts de prêtre. Par contre, il peut répliquer une partie conséquente des capacités en magie profane du lanceur. Il peut lancer tout sort de niveau 1 mémorisé par le lanceur pour ce jour.
+~
+@6273   = ~Simulacre mineur~
+@6274   = ~Simulacre mineur
+
+Niveau : 7
+École : Illusion
+Portée : 0
+Durée : 1 round par niveau
+Temps d'incantation : 2
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce sort, qui se lance très rapidement, crée une assez bonne copie du lanceur, qui peut être perçue par les gens alentour par leur cinq sens. Le clone a 60 % des points de vie du lanceur et une pénalité de 5 points aux jets d'attaque et au niveau effectif de lanceur. Le clone ne peut utiliser l'objets consommables comme les potions ou les parchemins (qui ne sont pas réellement dupliqués) et ne peut pas lancer de sorts de prêtre. Il peut répliquer une partie raisonnable des capacités en magie profane du lanceur. Il peut lancer tout sort jusqu'au niveau 4 mémorisé par le lanceur pour ce jour. Dès que le sort est lancé, le lanceur devient invisible pour 60 s. Un spectateur peu attentif pourra facilement croire que le clone est le lanceur et le lanceur pourra profiter de la distraction pour se déplacer ou prendre une position avantageuse.
+~
+@6275   = ~Simulacre~
+@6276   = ~Simulacre
+
+Niveau : 8
+École : Illusion
+Portée : 0
+Durée : 1 round par niveau
+Temps d'incantation : 5
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+C'est une version améliorée du sort Simulacre mineur. Le clone a 75 % des points de vie du lanceur et une pénalité de 3 points aux jets d'attaque et au niveau effectif de lanceur de sorts. Le clone ne peut utiliser l'objets consommables comme les potions ou les parchemins (qui ne sont pas réellement dupliqués). Par contre, il peut répliquer une partie conséquente des capacités en magie profane du lanceur. Le clone est capable de lancer tous les sorts profanes mémorisés jusqu'au niveau 7. De plus, le clone est si réel et a un tel sentiment d'identité qu'il est capable d'utiliser la magie divine (si la cible du sort en est capable). Une fois le sort lancé, le lanceur se retrouve sous l'effet d'Invisibilité majeure et peut se déplacer sans être vu et même attaquer ou lancer des sorts sans devenir complètement visible.
+~
+
+@6277   = ~Simulacre projeté~
+@6278   = ~Simulacre projeté
+
+Niveau : 9
+École : Illusion
+Portée : Toucher
+Durée : 1 round par niveau
+Temps d'incantation : 5
+Zone d'effet : une créature
+Jet de sauvegarde : Aucun
+
+Ce puissant sort crée un clone d'une créature ciblée, comme le sort de niveau 8 Simulacre. Le clone a 75 % des points de vie de la créature et une pénalité de 3 points aux jets d'attaque et au niveau effectif de lanceur de sorts (quand c'est opportun). Le clone ne peut utiliser d'objets consommables comme les potions ou les parchemins (qui ne sont pas réellement dupliqués). Par contre, il peut répliquer une partie conséquente des capacités en magie profane de la cible, si celle-ci en a. Le clone est capable de lancer tous les sorts profanes mémorisés jusqu'au niveau 7. De plus, le clone est si réel et a un tel sentiment d'identité qu'il est capable d'utiliser la magie divine (si la cible du sort en est capable).
+~
+
+@6279  = ~Clone d'ombre~
+@6280  = ~Clone d'ombre
+
+Niveau : 5
+École : Illusion
+Portée : 0
+Durée : 6 rounds
+Temps d'incantation : 1
+Zone d'effet : le lanceur
+Jet de sauvegarde : Aucun
+
+Ce sort rend le lanceur invisible, à part son ombre. Cette ombre peut se déplacer indépendamment du lanceur et, même si elle ne peut exécuter d'action comme attaquer ou lancer des sorts, elle peut servir de leurre pour le magicien invisible. Le lanceur sera protégé par l'invisibilité tant que l'ombre n'a pas été détruite, mais deviendra visible dès que l'ombre sera détruite ou dissipée.
+~
+
+@6351 = ~Contingence~
+@6352 = ~Contingence
+
+Cette faculté permet au lanceur de choisir un sort parmi ceux qu'il connaît (un niveau de sort par 3 niveaux du lanceur, arrondi au-dessus, soit un sort de 7e niveau au maximum pour un magicien de niveau 19). Ensuite, le magicien spécifie une condition parmi les options fournies. Cette condition peut aller d'être repéré par un ennemi à atteindre 10 % de ses points de vie. Quand cette condition sera remplie, le sort sera automatiquement et instantanément lancé, sans requérir d'action de la part du magicien.
+
+Par exemple, un magicien du 12e niveau pourrait placer une Contingence avec le sort Peau de pierre, et comme condition « 50 % des points de vie ». Ainsi, en combat, dès qu'il sera réduit à 50 % ou moins de ses points de vie, le sort Peau de pierre sera lancé.
+~
+@6353 = ~Chaîne de contingence~
+@6354 = ~Chaîne de contingence
+
+La chaîne de contingence canalise une partie de l'énergie magique du lanceur et ne la relâche que sous certaines conditions. Le magicien choisit trois sorts qui ne seront activés que lorsque la condition spécifiée est remplie, par exemple lorsqu'il subit des dégâts. Dans ce cas, les trois sorts sont immédiatement lancés. Les sorts jusqu'au niveau 8 ou inférieur peuvent être utilisés dans la contingence.
+~
+@6413 = ~Non-détection~
+@6414 = ~Non-détection
+(Abjuration)
+
+Niveau : 3
+Portée : contact
+Durée : 8 heures
+Temps d'incantation : 3
+Zone d'effet : 1 créature
+Jet de sauvegarde : aucun
+
+Une fois ce sort lancé, si la cible devient invisible, sanctuarisée ou se cache, les sorts de divination tels que Élimination des invisibilités, Oracle, Vision véritable, ou la capacité de voleur Détection des illusions ne permettront pas de dissiper l'invisibilité ou de révéler la créature cachée. Par contre, quelqu'un capable de percevoir les créatures invisibles sera en mesure de détecter et de cibler le bénéficiaire de ce sort.
+~
+
+@7103  = ~Identification~
+@7104  = ~Identification
+(Divination)
+
+Niveau : 1
+Portée : 0
+Durée : instantanée
+Temps d'incantation : 2
+Zone d'effet : le lanceur
+Jet de sauvegarde : aucun
+
+Quand ce sort est jeté, le nom et les enchantements (malédictions incluses) d'un objet ou d'une arme touchée par le lanceur lui sont révélés sans condition. Le lanceur a alors un aperçu de l'histoire, de la nature, des enchantements et de l'usage de l'objet. Beaucoup d'objets non identifiés peuvent être utilisés malgré tout, mais le risque est bien plus grand.
+
+Aux niveaux 5, 9 et 13, le nombre d'objets qui peuvent être identifiés par ce sort augmente de 1 (avec un maximum de 4 objets au niveau 13).
+~
+@8003  = ~Familier
+(Conjuration/Convocation)
+
+Niveau : 1
+Portée : n/d
+Durée : Spéciale
+Temps d'incantation : 9
+Zone d'effet : 1 familier
+Jet de sauvegarde : aucun
+
+Ce sort permet au magicien de tenter la convocation d'un familier qui deviendra son aide et son compagnon. Les familiers sont généralement de petites créatures. Une créature agissant en tant que familier peut aider un magicien en envoyant ses pouvoirs sensoriels vers son maître, en lui parlant ou en lui servant de garde, d'éclaireur ou d'espion. Un magicien ne peut avoir qu'un seul familier à la fois, et il ne contrôle pas le type de créature qui sera convoquée par le sort, Si tant est qu'il y en ait une.
+
+Remarque : Ce sort ne peut être lancé que par le protagoniste.
+
+La créature est toujours plus intelligente que les autres de même type (généralement de 2 ou 3 points d'intelligence), et ses liens avec le magicien lui confèrent une vie particulièrement longue. Le magicien garde un lien empathique avec le familier et peut lui transmettre des ordres mentalement. Ce lien lui permet aussi de ne pas mourir réellement. Si le familier venait à mourir au combat, le maître peut lancer à nouveau Familier le jour suivant et rappeler son familier.
+
+Voici une liste des familiers qu'un joueur peut convoquer en fonction de son alignement :
+
+LOYAL BON, NEUTRE BON : Pseudo-dragon
+Points de vie : 24
+Classe d'armure : -2
+Résistance à la magie : 50 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d3. Jet de sauvegarde contre mort sous peine d'inconscience pendant 2 tours.
+– Capacités spéciales : peut lancer Flou une fois par jour. Régénère 1 point de vie par tour. Immunisé contre Drain de niveau, Sommeil et Pétrification.
+
+LOYAL NEUTRE : Furet
+Points de vie : 24
+Classe d'armure : 0
+Résistance à la magie : 50 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d3.
+Capacités spéciales : 75 % vol à la tire, 40 % camouflage dans l'ombre & déplacements silencieux, et 20 % détection des pièges. Peut lancer Flou une fois par jour. Immunisé contre Drain de niveau, Sommeil et Pétrification.
+
+LOYAL MAUVAIS : Diablotin
+Points de vie : 18
+Classe d'armure : 2
+Résistance à la magie : 25 %
+Combat : 1 attaque par tour. TAC0 15, dégâts 1d6.
+Capacités spéciales : 100 % de résistance au feu, au froid et à l'électricité. Peut lancer le sort de Métamorphose une fois par jour. Régénère 1 point de vie par tour.
+
+NEUTRE : Lapin
+Points de vie : 24
+Classe d'armure : -4
+Résistance à la magie : 65 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d2.
+Capacités spéciales : 50 % détection des pièges, 30 % camouflage dans l'ombre & déplacements silencieux. 75 % de résistance au feu, au froid et à l'électricité.
+
+NEUTRE MAUVAIS : Méphite poussiéreux
+Points de vie : 24
+Classe d'armure : 6
+Résistance à la magie : 10 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d2.
+Capacités spéciales : 100 % de résistance au feu et 50 % de résistance aux dégâts tranchants, perforants et de projectiles. Peut lancer les sorts Poussière Scintillante 1 fois par jour et Poussière de verre 2 fois par jour. Régénère 1 point de vie par tour. Immunisé contre Drain de niveau, Sommeil et Pétrification.
+
+CHAOTIQUE BON : Dragon fée
+Points de vie : 24
+Classe d'armure : 4
+Résistance à la magie : 32 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d2.
+Capacités spéciales : Peut lancer les sorts Image Miroir & Invisibilité sur 3 mètres, une fois par jour. Immunisé contre Drain de niveau, Sommeil et Pétrification.
+
+CHAOTIQUE NEUTRE : Chat
+Points de vie : 24
+Classe d'armure : 0
+Résistance à la magie : 50 %
+Combat : 2 attaques par tour. TAC0 13, dégâts 1d3.
+Capacités spéciales : 30 % vol à la tire et 99 % déplacements silencieux & camouflage dans l'ombre. Immunisé contre Drain de niveau, Sommeil et Pétrification.
+
+CHAOTIQUE MAUVAIS : Quasit
+Points de vie : 24
+Classe d'armure : 2
+Résistance à la magie : 25 %
+Combat : 3 attaques par tour. TAC0 13, dégâts 1d6.
+Capacités spéciales : 100 % de résistance au feu, au froid et à l'électricité. Peut lancer les sorts Horreur et Flou une fois par jour. Régénère 1 point de vie par tour.
+~
+@8004  = ~Familier
+(Conjuration/Convocation)
+
+Niveau : 1
+Portée : n/d
+Durée : Spéciale
+Temps d'incantation : 9
+Zone d'effet : 1 familier
+Jet de sauvegarde : aucun
+
+Ce sort permet au magicien de tenter la convocation d'un familier qui deviendra son aide et son compagnon. Les familiers sont généralement de petites créatures. Une créature agissant en tant que familier peut aider un magicien en envoyant ses pouvoirs sensoriels vers son maître, en lui parlant ou en lui servant de garde, d'éclaireur ou d'espion. Un magicien ne peut avoir qu'un seul familier à la fois, et il ne contrôle pas le type de créature qui sera convoquée par le sort, Si tant est qu'il y en ait une.
+
+La créature est toujours plus intelligente que les autres de même type (généralement de 2 ou 3 points d'intelligence), et ses liens avec le magicien lui confèrent une vie particulièrement longue. Le magicien garde un lien empathique avec le familier et peut lui transmettre des ordres mentalement. Ce lien lui permet aussi de ne pas mourir réellement. Si le familier venait à mourir au combat, le maître peut lancer à nouveau Familier le jour suivant et rappeler son familier.
+
+Au niveau 1, tous les familiers partagent les mêmes caractéristiques : 9 points de vie, CA 4, TAC0 17, jets de sauvegarde 16, résistance à la magie et aux dégâts 25 %, immunisé à l'absorption de niveau et à la pétrification. À certains seuils d'expérience - 5 000 / 50 000 / 150 000 / 450 000 / 1 250 000 / 2 500 000 / 4 000 000 - les points de vie, la CA, le TAC0 et les jets de sauvegarde du familier s'améliorent.
+
+Voici une liste des familiers qu'un joueur peut choisir :
+
+Pseudo-Dragon
+- Combat : 1 attaque par round pour 1d3 dégâts ; jet de sauvegarde ou Lenteur pour 2 rounds
+- Capacités spéciales : peut lancer Flou et Soin des blessures légères, et utilise un souffle de Vapeurs colorées, une fois tous les 3 tours.
+- Bénéfice spécial : le maître du pseudo-dragon a un total de points de vie 10 % plus élevé et régénère 1 point de vie par round.
+
+Furet
+- Combat : 1 attaque par round pour 1d3 dégâts
+- Capacités spéciales : a un score de Pickpocket de 80 %.Peut émettre une aura de Puanteur écœurante une fois par tour. Pour 5 rounds, les ennemis proches doivent réussir un jet de sauvegarde ou subir une pénalité de 3 points aux jets d'attaque et à la CA plus un risque d'échec des sorts de 30 %.
+- Bénéfice spécial : le maître du furet a un total de points de vie 10 % plus élevé et un bonus de 1 point à la constitution.
+
+Lapin
+- Combat : 1 attaque par round pour 1d2 dégâts
+- Capacités spéciales : a un score de Détection des pièges de 80 %. Peut creuser le sol pour échapper au danger (similaire à Pas de l'ombre) une fois par tour.
+- Bénéfice spécial : le maître du lapin a un total de points de vie 10 % plus élevé et est immunisé aux effets de Lenteur.
+
+Chat
+- Combat : 1 attaque par round pour 1d3 dégâts
+- Capacités spéciales : a des scores de Déplacement silencieux et Se cacher dans l'ombre de 99 % et est sous l'effet de Non-détection (le sort) pour éviter les sorts de divination.
+- Bénéfice spécial : le maître du chat a un total de points de vie 10 % plus élevé et un bonus de 1 point à la dextérité.
+
+Araignée
+- Combat : 1 attaque par round pour 1d2 dégâts ; jet de sauvegarde ou 3 dégâts poison sur 1 round
+- Capacités spéciales : peut lancer une Toile sur une seule cible, qui l'enchevêtre pour 3 rounds, une fois tous les cinq rounds.
+- Bénéfice spécial : le maître de l'araignée a un total de points de vie 10 % plus élevé et a une chance supplémentaire pour éviter les effets des poisons.
+
+Rat
+- Combat : 1 attaque par round pour 1d2 dégâts  jet de sauvegarde ou malade pour 3 rounds, avec réduction de la force et 30 % de risque d'échec des sorts.
+- Capacités spéciales : peut convoquer une cohorte de 1d6 rats supplémentaires pour le défendre, une fois tous les 3 tours.
+- Bénéfice spécial : le maître du rat a un total de points de vie 10 % plus élevé et un bonus de 1 point à l'intelligence.
+~
+// used to replace Level:1 with Level: 2 in spell descriptions and for identify spell tweak
+@150000 = ~Niveau[^:]*: 1~
+@150001 = ~Niveau : 2~
+@150002 = ~Niveau : ~
+// invisibility tweak
+@150003 = ~5[^r][^r]?rounds~ //original
+@150004 = ~10 rounds~ //replacement
+
+// used to remove school from a scroll description
+// no SR
+@160000 = ~(Abjuration)~
+@160001 = ~(Transmutation)~
+@160002 = ~(Conjuration)~
+@160003 = ~(Conjuration/Convocation)~
+@160004 = ~(Divination)~
+@160005 = ~(Enchantement/Charme)~
+@160006 = ~(Évocation)~
+@160007 = ~(Illusion/Fantasme)~
+@160008 = ~(Nécromancie)~
+@160009 = ~(Invocation/Évocation)~
+@160010 = ~(Transmutation, Illusion)~
+@160011 = ~(Abjuration, Invocation/Évocation)~
+@160012 = ~(Divination, Transmutation)~
+@160013 = ~(Abjuration, Transmutation)~
+@160014 = ~(Conjuration/Convocation, Invocation/Évocation)~
+@160015 = ~(Enchantement)~
+@160016 = ~(Illusion)~
+@160017 = ~(Invocation)~
+@160018 = ~(Transmutation, Invocation)~
+@160019 = ~(Transmutation, Nécromancie)~
+@160020 = ~(Transmutation, Enchantement)~
+@160021 = ~(Invocation, Transmutation)~
+@160022 = ~(Divination, Transmutation)~
+@160023 = ~(Nécromancie, Conjuration)~
+@160024 = ~(Abjuration, Invocation)~
+@160025 = ~(Conjuration/Convocation, Nécromancie)~
+@160026 = ~(Convocation)~
+@160027 = ~(Conjuration)~
+@160028 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160029 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160030 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160031 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160032 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160033 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160034 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+@160035 = ~zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz123~
+//SR replacement
+@160100 = ~: Abjuration~
+@160101 = ~: Transmutation~
+@160102 = ~: Conjuration~
+@160103 = ~: Divination~
+@160104 = ~: Enchantement~
+@160105 = ~: [EÉ]vocation~
+@160106 = ~: Illusion~
+@160107 = ~: Nécromancie~
+@160110 = ~: Universelle~
+//non-SR replacement
+@160140 = ~(Abjuration)~
+@160141 = ~(Transmutation)~
+@160142 = ~(Conjuration/Convocation)~
+@160143 = ~(Divination)~
+@160144 = ~(Enchantement/Charme)~
+@160145 = ~(Invocation/Évocation)~
+@160146 = ~(Illusion/Fantasme)~
+@160147 = ~(Nécromancie)~
+@160150 = ~ ~ //universal

--- a/TomeAndBlood/lib/semi_spont/fr_FR/semi_spont.tra
+++ b/TomeAndBlood/lib/semi_spont/fr_FR/semi_spont.tra
@@ -54,7 +54,7 @@ On raconte que jadis, un grand magicien amnien défia les pouvoirs magiques de M
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveau 1
+– Une fois par jour, double les sorts profanes de niveau 1
 
 Poids : 0~
 @611 = ~Anneau de sorcellerie de Kontik~
@@ -64,7 +64,7 @@ Kontik, puissante magicienne au service d'Aurile, a pris cet anneau à un ennemi
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveaux 1 et 2
+– Une fois par jour, double les sorts profanes de niveaux 1 et 2
 
 Capacités de combat :
 - tous les dégâts de froid infligés par le porteur sont augmentés de 15%
@@ -79,7 +79,7 @@ Ce puissant anneau appartenait récemment à Édion, nécromancien mourant natif
 PARAMÈTRES :
 
 Capacités d'équipement :
-– Une fois par jour, permet de rafraîchir tous les sorts profanes de niveau 5
+– Une fois par jour, double les sorts profanes de niveau 5
 
 Poids : 0~
 //


### PR DESCRIPTION
This provides a french translation fro Tome And Blood as of 0.9.34.
Some parts that are probably unused (crafting) are still translated (but that's probably a waste of time I guess).
It includes the same translation as 5E_spellcasting for the lib/semi_spont part.

@subtledoctor youcan merge it if you're interested and if that's not hindering you for future developments.
You could still add a fallback on english/setup.tra for french to keep it installable but that wouldn't work for things like regexp replacing.